### PR TITLE
feat: auto-refresh with market hours awareness

### DIFF
--- a/docs/plans/2026-03-21-auto-refresh.md
+++ b/docs/plans/2026-03-21-auto-refresh.md
@@ -1,0 +1,24 @@
+# Auto-refresh with Market Hours Awareness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Auto-refresh options data during market hours (default: ON at 60s), with market state display in the status bar and ctrl+p to pause/unpause.
+
+**Architecture:** A `market_hours.py` module provides timezone-based market state detection (no API calls needed). The app uses Textual's `set_timer` for periodic refresh, adjusting interval based on market state. Status bar shows market state and countdown to next refresh.
+
+**Tech Stack:** Python `zoneinfo` (stdlib, no pytz needed on 3.11+), Textual timers
+
+---
+
+## Tasks
+
+### Task 1: Market Hours Module
+Create `src/tenortui/market_hours.py` — pure time-based US market state detection.
+
+### Task 2: Status Bar Market State Display
+Show market state and refresh countdown in status bar.
+
+### Task 3: Auto-refresh Timer in App
+Wire up periodic refresh with market-aware intervals and ctrl+p toggle.
+
+### Task 4: Tests, Lint, PR

--- a/src/tenortui/app.py
+++ b/src/tenortui/app.py
@@ -4,11 +4,13 @@ import sys
 
 from textual import work
 from textual.app import App, ComposeResult
+from textual.binding import Binding
 from textual.containers import Vertical
 
 from tenortui.config import load_config
 from tenortui.exceptions import ConfigError, ProviderError, SymbolNotFoundError
 from tenortui.history import load_history, add_to_history
+from tenortui.market_hours import MarketState, get_market_state
 from tenortui.providers import PROVIDERS
 from tenortui.providers.yahoo import batch_quotes
 from tenortui.widgets.chain_table import ChainTable
@@ -29,7 +31,11 @@ class TenorTUI(App):
         ("slash", "focus_search", "Search"),
         ("s", "focus_search", "Search"),
         ("ctrl+r", "refresh", "Refresh"),
+        Binding("ctrl+p", "toggle_auto_refresh", "Pause Refresh", priority=True),
     ]
+
+    DEFAULT_REFRESH_INTERVAL = 60  # seconds
+    OFF_HOURS_REFRESH_INTERVAL = 300  # 5 minutes when market closed
 
     def __init__(self, provider):
         super().__init__()
@@ -39,6 +45,10 @@ class TenorTUI(App):
         self._current_price: float | None = None
         self._loading_ticker: bool = False
         self._history = load_history()
+        self._auto_refresh_enabled: bool = True
+        self._auto_refresh_countdown: int = 0
+        self._refresh_timer = None
+        self._countdown_timer = None
 
     def compose(self) -> ComposeResult:
         yield TickerBar()
@@ -57,6 +67,9 @@ class TenorTUI(App):
             self._fetch_recent_quotes()
         else:
             recently_viewed.display = False
+        self._update_market_display()
+        # Update market state display every 60s
+        self.set_interval(60, self._update_market_display)
 
     def on_ticker_bar_ticker_submitted(self, event: TickerBar.TickerSubmitted) -> None:
         self._current_symbol = event.symbol
@@ -81,6 +94,66 @@ class TenorTUI(App):
 
     def action_command_palette(self) -> None:
         self.query_one(CommandPalette).open()
+
+    def action_toggle_auto_refresh(self) -> None:
+        """Toggle auto-refresh on/off."""
+        self._auto_refresh_enabled = not self._auto_refresh_enabled
+        if self._auto_refresh_enabled:
+            self._start_auto_refresh()
+        else:
+            self._stop_auto_refresh()
+            self.query_one(StatusBar).update_refresh_status(paused=True)
+
+    def _get_refresh_interval(self) -> int:
+        """Get refresh interval based on market state."""
+        state = get_market_state()
+        if state == MarketState.REGULAR:
+            return self.DEFAULT_REFRESH_INTERVAL
+        elif state in (MarketState.PRE_MARKET, MarketState.AFTER_HOURS):
+            return self.DEFAULT_REFRESH_INTERVAL * 2  # 2x during extended hours
+        else:
+            return self.OFF_HOURS_REFRESH_INTERVAL
+
+    def _start_auto_refresh(self) -> None:
+        """Start the auto-refresh timer."""
+        self._stop_auto_refresh()
+        interval = self._get_refresh_interval()
+        self._auto_refresh_countdown = interval
+        self._refresh_timer = self.set_timer(interval, self._on_auto_refresh)
+        self._countdown_timer = self.set_interval(1, self._on_countdown_tick)
+        self.query_one(StatusBar).update_refresh_status(seconds_until=interval)
+
+    def _stop_auto_refresh(self) -> None:
+        """Stop the auto-refresh timer."""
+        if self._refresh_timer is not None:
+            self._refresh_timer.stop()
+            self._refresh_timer = None
+        if self._countdown_timer is not None:
+            self._countdown_timer.stop()
+            self._countdown_timer = None
+
+    def _on_countdown_tick(self) -> None:
+        """Update the countdown display every second."""
+        if self._auto_refresh_countdown > 0:
+            self._auto_refresh_countdown -= 1
+        self.query_one(StatusBar).update_refresh_status(
+            seconds_until=self._auto_refresh_countdown
+        )
+
+    def _on_auto_refresh(self) -> None:
+        """Fired when the auto-refresh timer expires."""
+        if self._current_symbol and self._auto_refresh_enabled:
+            if self._current_expiration:
+                self._load_chain(self._current_symbol, self._current_expiration)
+            else:
+                self._load_ticker(self._current_symbol)
+        # Restart with potentially different interval (market state may have changed)
+        if self._auto_refresh_enabled:
+            self._start_auto_refresh()
+
+    def _update_market_display(self) -> None:
+        """Update the market state in the status bar."""
+        self.query_one(StatusBar).update_market_state()
 
     def _focus_first_table(self) -> None:
         """Focus the first (calls) DataTable so j/k navigation works immediately."""
@@ -235,6 +308,8 @@ class TenorTUI(App):
         self._loading_ticker = False
         self.query_one(StatusBar).update_refresh_time()
         self._focus_first_table()
+        if self._auto_refresh_enabled:
+            self._start_auto_refresh()
 
     @work(exclusive=True, group="chain")
     async def _load_chain(self, symbol: str, expiration: str) -> None:

--- a/src/tenortui/market_hours.py
+++ b/src/tenortui/market_hours.py
@@ -1,0 +1,87 @@
+from datetime import datetime
+from enum import Enum
+from zoneinfo import ZoneInfo
+
+ET = ZoneInfo("America/New_York")
+
+# US market hours in minutes from midnight ET
+PRE_MARKET_OPEN = 4 * 60  # 4:00 AM
+REGULAR_OPEN = 9 * 60 + 30  # 9:30 AM
+REGULAR_CLOSE = 16 * 60  # 4:00 PM
+AFTER_HOURS_CLOSE = 20 * 60  # 8:00 PM
+
+
+class MarketState(Enum):
+    PRE_MARKET = "PRE_MARKET"
+    REGULAR = "REGULAR"
+    AFTER_HOURS = "AFTER_HOURS"
+    CLOSED = "CLOSED"
+
+    @property
+    def display_name(self) -> str:
+        return {
+            MarketState.PRE_MARKET: "Pre-Market",
+            MarketState.REGULAR: "Market Open",
+            MarketState.AFTER_HOURS: "After-Hours",
+            MarketState.CLOSED: "Market Closed",
+        }[self]
+
+
+def _to_et(dt: datetime) -> datetime:
+    """Convert a datetime to ET. Treat naive datetimes as ET."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=ET)
+    return dt.astimezone(ET)
+
+
+def get_market_state(dt: datetime | None = None) -> MarketState:
+    """Determine US stock market state from time."""
+    if dt is None:
+        dt = datetime.now(ET)
+    else:
+        dt = _to_et(dt)
+
+    if dt.weekday() >= 5:  # Saturday=5, Sunday=6
+        return MarketState.CLOSED
+
+    mins = dt.hour * 60 + dt.minute
+
+    if mins < PRE_MARKET_OPEN:
+        return MarketState.CLOSED
+    elif mins < REGULAR_OPEN:
+        return MarketState.PRE_MARKET
+    elif mins < REGULAR_CLOSE:
+        return MarketState.REGULAR
+    elif mins < AFTER_HOURS_CLOSE:
+        return MarketState.AFTER_HOURS
+    else:
+        return MarketState.CLOSED
+
+
+def time_to_next_state(dt: datetime | None = None) -> int:
+    """Return minutes until the next market state transition."""
+    if dt is None:
+        dt = datetime.now(ET)
+    else:
+        dt = _to_et(dt)
+
+    mins = dt.hour * 60 + dt.minute
+    state = get_market_state(dt)
+
+    if state == MarketState.PRE_MARKET:
+        return REGULAR_OPEN - mins
+    elif state == MarketState.REGULAR:
+        return REGULAR_CLOSE - mins
+    elif state == MarketState.AFTER_HOURS:
+        return AFTER_HOURS_CLOSE - mins
+    else:
+        # Closed — return minutes to next pre-market (4 AM)
+        if dt.weekday() >= 5:  # Weekend
+            days_until_monday = 7 - dt.weekday()
+            return (days_until_monday * 24 * 60) - mins + PRE_MARKET_OPEN
+        elif mins >= AFTER_HOURS_CLOSE:
+            # After 8 PM, next day pre-market
+            return (24 * 60 - mins) + PRE_MARKET_OPEN
+        else:
+            # Before 4 AM
+            return PRE_MARKET_OPEN - mins

--- a/src/tenortui/widgets/help_overlay.py
+++ b/src/tenortui/widgets/help_overlay.py
@@ -21,6 +21,7 @@ KEYBINDINGS = [
         [
             ("/ or s", "Focus search bar"),
             ("r", "Refresh current data"),
+            ("Ctrl+P", "Pause / resume auto-refresh"),
             ("Enter", "Select / expand"),
             ("q", "Quit"),
         ],

--- a/src/tenortui/widgets/status_bar.py
+++ b/src/tenortui/widgets/status_bar.py
@@ -65,10 +65,7 @@ class StatusBar(Widget):
         with Horizontal():
             yield Static(self._provider_name, classes="status-provider")
             yield Static("", classes="status-market", id="status-market")
-            yield Static(
-                "? Help | / Search | r Refresh | ^P Pause | : Command | q Quit",
-                classes="status-keys",
-            )
+            yield Static("? Help", classes="status-keys")
             yield Static("", classes="status-refresh", id="status-refresh")
             yield Static(self._last_refresh, classes="status-time", id="status-time")
 

--- a/src/tenortui/widgets/status_bar.py
+++ b/src/tenortui/widgets/status_bar.py
@@ -5,6 +5,8 @@ from textual.containers import Horizontal
 from textual.widget import Widget
 from textual.widgets import Static
 
+from tenortui.market_hours import MarketState, get_market_state, time_to_next_state
+
 
 class StatusBar(Widget):
     DEFAULT_CSS = """
@@ -23,8 +25,28 @@ class StatusBar(Widget):
         padding: 0 1;
         color: $accent;
     }
+    StatusBar .status-market {
+        width: auto;
+        padding: 0 1;
+    }
+    StatusBar .status-market-open {
+        color: $success;
+    }
+    StatusBar .status-market-pre {
+        color: $warning;
+    }
+    StatusBar .status-market-post {
+        color: $warning;
+    }
+    StatusBar .status-market-closed {
+        color: $text-muted;
+    }
     StatusBar .status-keys {
         width: 1fr;
+        padding: 0 1;
+    }
+    StatusBar .status-refresh {
+        width: auto;
         padding: 0 1;
     }
     StatusBar .status-time {
@@ -37,15 +59,73 @@ class StatusBar(Widget):
         super().__init__()
         self._provider_name = provider_name
         self._last_refresh: str = ""
+        self._auto_refresh_paused: bool = False
 
     def compose(self) -> ComposeResult:
         with Horizontal():
             yield Static(self._provider_name, classes="status-provider")
+            yield Static("", classes="status-market", id="status-market")
             yield Static(
-                "? Help | / Search | r Refresh | : Command | q Quit",
+                "? Help | / Search | r Refresh | ^P Pause | : Command | q Quit",
                 classes="status-keys",
             )
+            yield Static("", classes="status-refresh", id="status-refresh")
             yield Static(self._last_refresh, classes="status-time", id="status-time")
+
+    def update_market_state(self) -> None:
+        """Update the market state display."""
+        state = get_market_state()
+        mins = time_to_next_state()
+
+        if mins >= 60:
+            hours = mins // 60
+            remaining_mins = mins % 60
+            countdown = f"{hours}h {remaining_mins}m"
+        else:
+            countdown = f"{mins}m"
+
+        if state == MarketState.REGULAR:
+            text = f"Market Open (closes in {countdown})"
+            css_class = "status-market-open"
+        elif state == MarketState.PRE_MARKET:
+            text = f"Pre-Market (opens in {countdown})"
+            css_class = "status-market-pre"
+        elif state == MarketState.AFTER_HOURS:
+            text = f"After-Hours (closes in {countdown})"
+            css_class = "status-market-post"
+        else:
+            text = "Market Closed"
+            css_class = "status-market-closed"
+
+        try:
+            market_widget = self.query_one("#status-market", Static)
+            market_widget.update(text)
+            for cls in (
+                "status-market-open",
+                "status-market-pre",
+                "status-market-post",
+                "status-market-closed",
+            ):
+                market_widget.remove_class(cls)
+            market_widget.add_class(css_class)
+        except Exception:
+            pass
+
+    def update_refresh_status(
+        self, seconds_until: int | None = None, paused: bool = False
+    ) -> None:
+        """Update the auto-refresh status display."""
+        self._auto_refresh_paused = paused
+        try:
+            widget = self.query_one("#status-refresh", Static)
+            if paused:
+                widget.update("⏸ Paused")
+            elif seconds_until is not None:
+                widget.update(f"↻ {seconds_until}s")
+            else:
+                widget.update("")
+        except Exception:
+            pass
 
     def update_refresh_time(self) -> None:
         now = datetime.now().strftime("%H:%M:%S")

--- a/tests/test_auto_refresh.py
+++ b/tests/test_auto_refresh.py
@@ -1,0 +1,163 @@
+"""Tests for auto-refresh and market hours integration."""
+
+import pytest
+from textual.app import App
+
+from tenortui.app import TenorTUI
+from tenortui.widgets.status_bar import StatusBar
+
+
+# --- Status Bar Market State ---
+
+
+@pytest.mark.asyncio
+async def test_status_bar_shows_market_state():
+    """Status bar displays market state after update."""
+
+    class StatusTestApp(App):
+        def compose(self):
+            yield StatusBar(provider_name="yahoo")
+
+    app = StatusTestApp()
+    async with app.run_test():
+        bar = app.query_one(StatusBar)
+        bar.update_market_state()
+        market_widget = bar.query_one("#status-market")
+        rendered = market_widget.render().plain
+        # Should contain one of the market states
+        assert any(
+            s in rendered
+            for s in ["Market Open", "Pre-Market", "After-Hours", "Market Closed"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_status_bar_refresh_countdown():
+    """Status bar shows refresh countdown."""
+
+    class StatusTestApp(App):
+        def compose(self):
+            yield StatusBar(provider_name="yahoo")
+
+    app = StatusTestApp()
+    async with app.run_test():
+        bar = app.query_one(StatusBar)
+        bar.update_refresh_status(seconds_until=45)
+        widget = bar.query_one("#status-refresh")
+        rendered = widget.render().plain
+        assert "45s" in rendered
+
+
+@pytest.mark.asyncio
+async def test_status_bar_refresh_paused():
+    """Status bar shows paused indicator."""
+
+    class StatusTestApp(App):
+        def compose(self):
+            yield StatusBar(provider_name="yahoo")
+
+    app = StatusTestApp()
+    async with app.run_test():
+        bar = app.query_one(StatusBar)
+        bar.update_refresh_status(paused=True)
+        widget = bar.query_one("#status-refresh")
+        rendered = widget.render().plain
+        assert "Paused" in rendered
+
+
+# --- Auto-refresh toggle ---
+
+
+@pytest.mark.asyncio
+async def test_auto_refresh_enabled_by_default(fake_provider, monkeypatch):
+    """Auto-refresh is enabled by default."""
+    monkeypatch.setattr("tenortui.app.load_history", lambda: [])
+    app = TenorTUI(provider=fake_provider)
+    async with app.run_test():
+        assert app._auto_refresh_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_toggle_auto_refresh(fake_provider, monkeypatch):
+    """Ctrl+P toggles auto-refresh on/off."""
+    monkeypatch.setattr("tenortui.app.load_history", lambda: [])
+    app = TenorTUI(provider=fake_provider)
+    async with app.run_test() as pilot:
+        assert app._auto_refresh_enabled is True
+
+        await pilot.press("ctrl+p")
+        assert app._auto_refresh_enabled is False
+
+        await pilot.press("ctrl+p")
+        assert app._auto_refresh_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_auto_refresh_starts_after_ticker_load(fake_provider, monkeypatch):
+    """Auto-refresh timer starts after loading a ticker."""
+    monkeypatch.setattr("tenortui.app.load_history", lambda: [])
+    monkeypatch.setattr("tenortui.app.add_to_history", lambda sym: [sym])
+    app = TenorTUI(provider=fake_provider)
+    async with app.run_test() as pilot:
+        app.action_focus_search()
+        await pilot.press(*"AAPL")
+        await pilot.press("enter")
+        await app.workers.wait_for_complete()
+
+        assert app._refresh_timer is not None
+        assert app._countdown_timer is not None
+
+
+@pytest.mark.asyncio
+async def test_auto_refresh_stops_when_paused(fake_provider, monkeypatch):
+    """Pausing auto-refresh stops the timers."""
+    monkeypatch.setattr("tenortui.app.load_history", lambda: [])
+    monkeypatch.setattr("tenortui.app.add_to_history", lambda sym: [sym])
+    app = TenorTUI(provider=fake_provider)
+    async with app.run_test() as pilot:
+        app.action_focus_search()
+        await pilot.press(*"AAPL")
+        await pilot.press("enter")
+        await app.workers.wait_for_complete()
+
+        # Pause
+        await pilot.press("ctrl+p")
+        assert app._auto_refresh_enabled is False
+
+
+# --- Refresh interval based on market state ---
+
+
+def test_refresh_interval_varies_by_market_state(fake_provider, monkeypatch):
+    """Refresh interval is different during/outside market hours."""
+    monkeypatch.setattr("tenortui.app.load_history", lambda: [])
+    app = TenorTUI(provider=fake_provider)
+
+    # During regular hours
+    from tenortui.market_hours import MarketState
+
+    monkeypatch.setattr("tenortui.app.get_market_state", lambda: MarketState.REGULAR)
+    assert app._get_refresh_interval() == 60
+
+    # During closed
+    monkeypatch.setattr("tenortui.app.get_market_state", lambda: MarketState.CLOSED)
+    assert app._get_refresh_interval() == 300
+
+    # During pre-market
+    monkeypatch.setattr("tenortui.app.get_market_state", lambda: MarketState.PRE_MARKET)
+    assert app._get_refresh_interval() == 120
+
+
+@pytest.mark.asyncio
+async def test_market_state_displayed_on_mount(fake_provider, monkeypatch):
+    """Market state is displayed in status bar on mount."""
+    monkeypatch.setattr("tenortui.app.load_history", lambda: [])
+    app = TenorTUI(provider=fake_provider)
+    async with app.run_test():
+        bar = app.query_one(StatusBar)
+        market = bar.query_one("#status-market")
+        rendered = market.render().plain
+        assert any(
+            s in rendered
+            for s in ["Market Open", "Pre-Market", "After-Hours", "Market Closed"]
+        )

--- a/tests/test_market_hours.py
+++ b/tests/test_market_hours.py
@@ -1,0 +1,111 @@
+"""Tests for market hours detection."""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from tenortui.market_hours import MarketState, get_market_state, time_to_next_state
+
+ET = ZoneInfo("America/New_York")
+
+
+class TestGetMarketState:
+    def test_regular_hours(self):
+        """10:00 AM ET on a Monday is regular trading."""
+        dt = datetime(2026, 3, 23, 10, 0, tzinfo=ET)  # Monday
+        assert get_market_state(dt) == MarketState.REGULAR
+
+    def test_regular_hours_open(self):
+        """9:30 AM ET is the start of regular trading."""
+        dt = datetime(2026, 3, 23, 9, 30, tzinfo=ET)
+        assert get_market_state(dt) == MarketState.REGULAR
+
+    def test_regular_hours_before_close(self):
+        """3:59 PM ET is still regular trading."""
+        dt = datetime(2026, 3, 23, 15, 59, tzinfo=ET)
+        assert get_market_state(dt) == MarketState.REGULAR
+
+    def test_pre_market(self):
+        """7:00 AM ET on a Tuesday is pre-market."""
+        dt = datetime(2026, 3, 24, 7, 0, tzinfo=ET)  # Tuesday
+        assert get_market_state(dt) == MarketState.PRE_MARKET
+
+    def test_pre_market_open(self):
+        """4:00 AM ET is the start of pre-market."""
+        dt = datetime(2026, 3, 23, 4, 0, tzinfo=ET)
+        assert get_market_state(dt) == MarketState.PRE_MARKET
+
+    def test_after_hours(self):
+        """5:00 PM ET is after-hours."""
+        dt = datetime(2026, 3, 23, 17, 0, tzinfo=ET)
+        assert get_market_state(dt) == MarketState.AFTER_HOURS
+
+    def test_after_hours_start(self):
+        """4:00 PM ET is the start of after-hours."""
+        dt = datetime(2026, 3, 23, 16, 0, tzinfo=ET)
+        assert get_market_state(dt) == MarketState.AFTER_HOURS
+
+    def test_closed_night(self):
+        """11:00 PM ET is closed."""
+        dt = datetime(2026, 3, 23, 23, 0, tzinfo=ET)
+        assert get_market_state(dt) == MarketState.CLOSED
+
+    def test_closed_early_morning(self):
+        """3:00 AM ET is closed."""
+        dt = datetime(2026, 3, 23, 3, 0, tzinfo=ET)
+        assert get_market_state(dt) == MarketState.CLOSED
+
+    def test_closed_weekend_saturday(self):
+        """Saturday is closed regardless of time."""
+        dt = datetime(2026, 3, 21, 10, 0, tzinfo=ET)  # Saturday
+        assert get_market_state(dt) == MarketState.CLOSED
+
+    def test_closed_weekend_sunday(self):
+        """Sunday is closed regardless of time."""
+        dt = datetime(2026, 3, 22, 10, 0, tzinfo=ET)  # Sunday
+        assert get_market_state(dt) == MarketState.CLOSED
+
+    def test_naive_datetime_treated_as_et(self):
+        """Naive datetime is treated as ET."""
+        dt = datetime(2026, 3, 23, 10, 0)  # No tzinfo, Monday
+        assert get_market_state(dt) == MarketState.REGULAR
+
+    def test_other_timezone_converted(self):
+        """UTC datetime is correctly converted to ET."""
+        # 2:00 PM UTC = 10:00 AM ET (during EDT)
+        utc = ZoneInfo("UTC")
+        dt = datetime(2026, 3, 23, 14, 0, tzinfo=utc)
+        assert get_market_state(dt) == MarketState.REGULAR
+
+
+class TestMarketStateDisplay:
+    def test_regular_display(self):
+        assert MarketState.REGULAR.display_name == "Market Open"
+
+    def test_pre_market_display(self):
+        assert MarketState.PRE_MARKET.display_name == "Pre-Market"
+
+    def test_after_hours_display(self):
+        assert MarketState.AFTER_HOURS.display_name == "After-Hours"
+
+    def test_closed_display(self):
+        assert MarketState.CLOSED.display_name == "Market Closed"
+
+
+class TestTimeToNextState:
+    def test_time_to_close_during_regular(self):
+        """During regular hours, returns time to close (4 PM ET)."""
+        dt = datetime(2026, 3, 23, 14, 0, tzinfo=ET)  # 2:00 PM
+        minutes = time_to_next_state(dt)
+        assert minutes == 120  # 2 hours to 4 PM
+
+    def test_time_to_open_during_pre_market(self):
+        """During pre-market, returns time to open (9:30 AM ET)."""
+        dt = datetime(2026, 3, 23, 8, 0, tzinfo=ET)  # 8:00 AM
+        minutes = time_to_next_state(dt)
+        assert minutes == 90  # 1.5 hours to 9:30 AM
+
+    def test_time_to_close_after_hours(self):
+        """During after-hours, returns time to close (8 PM ET)."""
+        dt = datetime(2026, 3, 23, 19, 0, tzinfo=ET)  # 7:00 PM
+        minutes = time_to_next_state(dt)
+        assert minutes == 60  # 1 hour to 8 PM


### PR DESCRIPTION
## Summary
- **Market hours detection**: Timezone-based US market state (Pre-Market, Regular, After-Hours, Closed) using stdlib `zoneinfo` — no API calls needed
- **Auto-refresh**: ON by default. 60s during market hours, 120s during extended hours, 300s when closed. Starts after first ticker load.
- **Status bar enhancements**:
  - Market state with countdown: "Market Open (closes in 2h 15m)"
  - Refresh countdown: "↻ 45s"
  - Pause indicator: "⏸ Paused"
- **Ctrl+P**: Toggle auto-refresh on/off
- **Help overlay**: Updated with Ctrl+P binding

### New files
- `src/tenortui/market_hours.py` — MarketState enum, `get_market_state()`, `time_to_next_state()`
- `tests/test_market_hours.py` — 20 tests for market hours logic
- `tests/test_auto_refresh.py` — 9 tests for auto-refresh integration
- `docs/plans/2026-03-21-auto-refresh.md` — Implementation plan

Closes #7

*Co-authored by Claude*

## Test plan
- [ ] 134 tests pass (29 new)
- [ ] Coverage at 90% (above threshold)
- [ ] Market state displays correctly in status bar
- [ ] Auto-refresh fires at configured interval after ticker load
- [ ] Ctrl+P pauses/resumes auto-refresh
- [ ] Refresh interval adapts to market state
- [ ] Lint and format checks pass