### PR TITLE
Add pre-commit and pre-push git hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.7
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.7
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,13 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: python -m pytest
+        language: system
+        stages: [pre-push]
+        always_run: true
+        pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,30 @@ bin/ci-watch <pr-number> --poll      # Poll until pass/fail
 bin/ci-watch <pr-number> --poll 15   # Custom interval (seconds)
 ```
 
+## Git Hooks
+
+This project uses [`pre-commit`](https://pre-commit.com/) for git hooks.
+
+### Setup
+
+```bash
+pre-commit install && pre-commit install --hook-type pre-push
+```
+
+### What runs
+
+- **Pre-commit:** `ruff check` (lint) and `ruff format --check` (format) on staged Python files
+- **Pre-push:** `python -m pytest` (full test suite)
+
+### Bypass
+
+Use `--no-verify` to skip hooks when needed:
+
+```bash
+git commit --no-verify -m "WIP"
+git push --no-verify
+```
+
 ## Architecture
 
 TenorTUI is a Textual-based terminal app for browsing stock options chains. Python 3.11+, built with hatchling.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ pre-commit install && pre-commit install --hook-type pre-push
 
 ### What runs
 
-- **Pre-commit:** `ruff check` (lint) and `ruff format --check` (format) on staged Python files
+- **Pre-commit:** `ruff check --fix` (lint with auto-fix) and `ruff format` (format in-place) on staged Python files
 - **Pre-push:** `python -m pytest` (full test suite)
 
 ### Bypass

--- a/docs/superpowers/plans/2026-03-21-git-hooks.md
+++ b/docs/superpowers/plans/2026-03-21-git-hooks.md
@@ -1,0 +1,223 @@
+# Git Hooks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add pre-commit (ruff lint + format) and pre-push (pytest) hooks using the `pre-commit` framework.
+
+**Architecture:** The `pre-commit` framework manages hooks via `.pre-commit-config.yaml`. Ruff hooks use the official `astral-sh/ruff-pre-commit` mirror. Pytest runs as a local hook on pre-push.
+
+**Tech Stack:** pre-commit, ruff, pytest
+
+---
+
+### Task 1: Add pre-commit to dev dependencies
+
+**Files:**
+- Modify: `pyproject.toml:21-28`
+
+- [ ] **Step 1: Add pre-commit to dev deps**
+
+In `pyproject.toml`, add `"pre-commit>=3.0"` to the `dev` optional-dependencies list:
+
+```toml
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21",
+    "pytest-cov>=4.0",
+    "pandas",
+    "ruff>=0.4",
+    "pre-commit>=3.0",
+]
+```
+
+- [ ] **Step 2: Reinstall with new dep**
+
+Run: `pip install -e ".[dev]"`
+Expected: pre-commit is installed successfully
+
+- [ ] **Step 3: Verify pre-commit is available**
+
+Run: `pre-commit --version`
+Expected: Output like `pre-commit 4.x.x`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml
+git commit -m "build: add pre-commit to dev dependencies"
+```
+
+---
+
+### Task 2: Create .pre-commit-config.yaml with ruff hooks
+
+**Files:**
+- Create: `.pre-commit-config.yaml`
+
+- [ ] **Step 1: Create the config file**
+
+Create `.pre-commit-config.yaml` at the repo root:
+
+```yaml
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.7
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+```
+
+Note: `rev` is pinned to match the currently installed ruff version. The `ruff` hook runs lint with auto-fix. The `ruff-format` hook runs the formatter. Both only run on staged `.py` files by default.
+
+- [ ] **Step 2: Install the pre-commit hooks**
+
+Run: `pre-commit install`
+Expected: `pre-commit installed at .git/hooks/pre-commit`
+
+- [ ] **Step 3: Verify hooks run on all files**
+
+Run: `pre-commit run --all-files`
+Expected: Both `ruff` and `ruff-format` pass (since the codebase already passes lint)
+
+- [ ] **Step 4: Test that hooks block on failure**
+
+Create a temporary file with a lint error, stage it, and verify the hook catches it:
+
+```bash
+echo "import os\nimport sys\nx=1" > /tmp/test_lint_fail.py
+cp /tmp/test_lint_fail.py test_lint_fail.py
+git add test_lint_fail.py
+pre-commit run --files test_lint_fail.py
+```
+
+Expected: ruff hook fails (unused imports)
+
+Then clean up:
+
+```bash
+git reset HEAD test_lint_fail.py
+rm test_lint_fail.py
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .pre-commit-config.yaml
+git commit -m "feat: add pre-commit config with ruff lint and format hooks"
+```
+
+---
+
+### Task 3: Add pre-push pytest hook
+
+**Files:**
+- Modify: `.pre-commit-config.yaml`
+
+- [ ] **Step 1: Add the local pytest hook to config**
+
+Append a second repo entry to `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: python -m pytest
+        language: system
+        stages: [pre-push]
+        always_run: true
+        pass_filenames: false
+```
+
+The full file should now be:
+
+```yaml
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.7
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: python -m pytest
+        language: system
+        stages: [pre-push]
+        always_run: true
+        pass_filenames: false
+```
+
+- [ ] **Step 2: Install the pre-push hook**
+
+Run: `pre-commit install --hook-type pre-push`
+Expected: `pre-commit installed at .git/hooks/pre-push`
+
+- [ ] **Step 3: Verify pytest hook runs**
+
+Run: `pre-commit run --hook-stage pre-push --all-files`
+Expected: pytest runs and passes
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .pre-commit-config.yaml
+git commit -m "feat: add pre-push pytest hook"
+```
+
+---
+
+### Task 4: Document hooks in CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md:7-32` (Commands section)
+
+- [ ] **Step 1: Add hooks documentation to CLAUDE.md**
+
+Add a new section after the existing Commands block (after line 32), before the Architecture section:
+
+```markdown
+## Git Hooks
+
+This project uses [`pre-commit`](https://pre-commit.com/) for git hooks.
+
+### Setup
+
+```bash
+pre-commit install && pre-commit install --hook-type pre-push
+```
+
+### What runs
+
+- **Pre-commit:** `ruff check` (lint) and `ruff format --check` (format) on staged Python files
+- **Pre-push:** `python -m pytest` (full test suite)
+
+### Bypass
+
+Use `--no-verify` to skip hooks when needed:
+
+```bash
+git commit --no-verify -m "WIP"
+git push --no-verify
+```
+```
+
+- [ ] **Step 2: Verify CLAUDE.md is valid markdown**
+
+Read through the file to confirm formatting is correct and sections flow logically.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add git hooks setup and usage to CLAUDE.md
+
+Closes #22
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```

--- a/docs/superpowers/specs/2026-03-21-git-hooks-design.md
+++ b/docs/superpowers/specs/2026-03-21-git-hooks-design.md
@@ -1,0 +1,67 @@
+# Git Hooks: Pre-commit and Pre-push
+
+## Summary
+
+Add git hooks using the `pre-commit` framework to enforce lint checks on commit and run the test suite on push. This mirrors the pattern used in the `tenor` Rails project (which uses Lefthook) but uses the Python-native `pre-commit` tool.
+
+## Motivation
+
+Currently there is no automated quality gate before code reaches CI. Developers can commit unlinted code and push failing tests. Adding local hooks catches these issues earlier, reducing CI churn and failed PRs.
+
+## Design
+
+### Framework: pre-commit
+
+The [`pre-commit`](https://pre-commit.com/) framework manages git hooks via a YAML config file. It is Python-native, widely adopted, and already compatible with ruff via the official mirror repo.
+
+### Hook Configuration
+
+A `.pre-commit-config.yaml` file at the repo root defines two hook stages:
+
+**Pre-commit (runs on every `git commit`):**
+- **ruff lint** — runs `ruff check` on staged Python files
+- **ruff format** — runs `ruff format --check` on staged Python files
+- Both use the `astral-sh/ruff-pre-commit` mirror, pinned to a specific ruff version (matching the `>=0.4` constraint in `pyproject.toml`)
+
+**Pre-push (runs on every `git push`):**
+- **pytest** — runs `python -m pytest` as a local hook
+- Configured with `always_run: true` and `pass_filenames: false` since it runs the full suite, not per-file
+
+### Installation
+
+Developers install hooks with:
+
+```bash
+pre-commit install && pre-commit install --hook-type pre-push
+```
+
+### Dependencies
+
+Add `pre-commit` to the `[project.optional-dependencies] dev` list in `pyproject.toml`. No other dependencies are needed — ruff is already a dev dependency, and pre-commit downloads its own isolated copy for the hooks.
+
+### Bypass
+
+Standard git `--no-verify` flag skips hooks when needed (e.g., WIP commits). No custom bypass mechanism required.
+
+### Documentation
+
+Update CLAUDE.md to document:
+- Hook installation command
+- What each hook does
+- How to bypass with `--no-verify`
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `.pre-commit-config.yaml` | New — hook configuration |
+| `pyproject.toml` | Add `pre-commit` to dev dependencies |
+| `CLAUDE.md` | Document hook setup and usage |
+
+## Success Criteria
+
+- [ ] Pre-commit hook runs ruff lint and format check on staged files
+- [ ] Pre-push hook runs pytest
+- [ ] Hooks block on failure (non-zero exit)
+- [ ] Easy to install (`pre-commit install && pre-commit install --hook-type pre-push`)
+- [ ] Documented in CLAUDE.md

--- a/poetry.lock
+++ b/poetry.lock
@@ -133,6 +133,18 @@ files = [
 pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+description = "Validate configuration and produce human readable error messages."
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0"},
+    {file = "cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132"},
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.6"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -434,6 +446,30 @@ extra = ["lxml_html_clean", "markdownify (>=1.1.0)", "readability-lxml (>=0.8.1)
 test = ["charset_normalizer (>=3.3.2,<4.0)", "cryptography (>=42.0.5,<43.0)", "fastapi (==0.110.0)", "httpx (==0.23.1)", "proxy.py (>=2.4.3,<3.0)", "pytest (>=8.1.1,<9.0)", "pytest-asyncio (>=0.23.6,<1.0)", "pytest-trio (>=0.8.0,<1.0)", "python-multipart (>=0.0.9,<1.0)", "trio (>=0.25.0,<1.0)", "trustme (>=1.1.0,<2.0)", "typing_extensions", "uvicorn (>=0.29.0,<1.0)", "websockets (>=12.0,<13.0)"]
 
 [[package]]
+name = "distlib"
+version = "0.4.0"
+description = "Distribution utilities"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16"},
+    {file = "distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d"},
+]
+
+[[package]]
+name = "filelock"
+version = "3.25.2"
+description = "A platform independent file lock."
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70"},
+    {file = "filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694"},
+]
+
+[[package]]
 name = "frozendict"
 version = "2.4.7"
 description = "A simple immutable dictionary"
@@ -533,6 +569,21 @@ files = [
     {file = "frozendict-2.4.7-py3-none-any.whl", hash = "sha256:972af65924ea25cf5b4d9326d549e69a9a4918d8a76a9d3a7cd174d98b237550"},
     {file = "frozendict-2.4.7.tar.gz", hash = "sha256:e478fb2a1391a56c8a6e10cc97c4a9002b410ecd1ac28c18d780661762e271bd"},
 ]
+
+[[package]]
+name = "identify"
+version = "2.6.18"
+description = "File identification library for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "identify-2.6.18-py2.py3-none-any.whl", hash = "sha256:8db9d3c8ea9079db92cafb0ebf97abdc09d52e97f4dcf773a2e694048b7cd737"},
+    {file = "identify-2.6.18.tar.gz", hash = "sha256:873ac56a5e3fd63e7438a7ecbc4d91aca692eb3fefa4534db2b7913f3fc352fd"},
+]
+
+[package.extras]
+license = ["ukkonen"]
 
 [[package]]
 name = "idna"
@@ -648,6 +699,18 @@ python-versions = "*"
 groups = ["main"]
 files = [
     {file = "multitasking-0.0.12.tar.gz", hash = "sha256:2fba2fa8ed8c4b85e227c5dd7dc41c7d658de3b6f247927316175a57349b84d1"},
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+description = "Node.js virtual environment builder"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+groups = ["dev"]
+files = [
+    {file = "nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827"},
+    {file = "nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb"},
 ]
 
 [[package]]
@@ -863,7 +926,7 @@ version = "4.9.4"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868"},
     {file = "platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934"},
@@ -884,6 +947,25 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pre-commit"
+version = "4.5.1"
+description = "A framework for managing and maintaining multi-language pre-commit hooks."
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77"},
+    {file = "pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61"},
+]
+
+[package.dependencies]
+cfgv = ">=2.0.0"
+identify = ">=1.0.0"
+nodeenv = ">=0.11.1"
+pyyaml = ">=5.1"
+virtualenv = ">=20.10.0"
 
 [[package]]
 name = "protobuf"
@@ -1009,6 +1091,26 @@ files = [
 six = ">=1.5"
 
 [[package]]
+name = "python-discovery"
+version = "1.2.0"
+description = "Python interpreter discovery"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "python_discovery-1.2.0-py3-none-any.whl", hash = "sha256:1e108f1bbe2ed0ef089823d28805d5ad32be8e734b86a5f212bf89b71c266e4a"},
+    {file = "python_discovery-1.2.0.tar.gz", hash = "sha256:7d33e350704818b09e3da2bd419d37e21e7c30db6e0977bb438916e06b41b5b1"},
+]
+
+[package.dependencies]
+filelock = ">=3.15.4"
+platformdirs = ">=4.3.6,<5"
+
+[package.extras]
+docs = ["furo (>=2025.12.19)", "sphinx (>=9.1)", "sphinx-autodoc-typehints (>=3.6.3)", "sphinxcontrib-mermaid (>=2)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.5.4)", "pytest (>=8.3.5)", "pytest-mock (>=3.14)", "setuptools (>=75.1)"]
+
+[[package]]
 name = "pytz"
 version = "2026.1.post1"
 description = "World timezone definitions, modern and historical"
@@ -1026,7 +1128,7 @@ version = "6.0.3"
 description = "YAML parser and emitter for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
     {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
@@ -1279,6 +1381,24 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
+name = "virtualenv"
+version = "21.2.0"
+description = "Virtual Python Environment builder"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "virtualenv-21.2.0-py3-none-any.whl", hash = "sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f"},
+    {file = "virtualenv-21.2.0.tar.gz", hash = "sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098"},
+]
+
+[package.dependencies]
+distlib = ">=0.3.7,<1"
+filelock = {version = ">=3.24.2,<4", markers = "python_version >= \"3.10\""}
+platformdirs = ">=3.9.1,<5"
+python-discovery = ">=1"
+
+[[package]]
 name = "websockets"
 version = "16.0"
 description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
@@ -1382,4 +1502,4 @@ repair = ["scipy (>=1.6.3)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "dcf8bcca4be602a1f6a53c7acc417651b4db87bd955099b2d9f53d32275d4f02"
+content-hash = "f78d7e4d23fb936950f377a28013407d81762852ff79a138605129bd2d2fd567"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ pytest-asyncio = ">=0.21"
 pytest-cov = ">=4.0"
 pandas = "*"
 ruff = ">=0.4"
+pre-commit = ">=3.0"
 
 [tool.poetry.scripts]
 tenortui = "tenortui.app:main"


### PR DESCRIPTION
## Summary
- Add `pre-commit` framework with ruff lint/format hooks (pre-commit) and pytest hook (pre-push)
- New `.pre-commit-config.yaml` using `astral-sh/ruff-pre-commit` mirror and local pytest hook
- Document hook setup, usage, and bypass in CLAUDE.md

Closes #22

*Co-authored by Claude*