### PR TITLE
feat: add j/k/g/G scrolling to help overlay

### DIFF
--- a/src/tenortui/widgets/help_overlay.py
+++ b/src/tenortui/widgets/help_overlay.py
@@ -74,7 +74,23 @@ class HelpOverlay(ModalScreen):
     BINDINGS = [
         Binding("escape", "dismiss", "Close", show=False),
         Binding("question_mark", "dismiss", "Close", show=False),
+        Binding("j", "scroll_down", "Scroll down", show=False),
+        Binding("k", "scroll_up", "Scroll up", show=False),
+        Binding("g", "scroll_top", "Scroll to top", show=False),
+        Binding("G", "scroll_bottom", "Scroll to bottom", show=False),
     ]
+
+    def action_scroll_down(self) -> None:
+        self.query_one("#help-container").scroll_relative(y=1)
+
+    def action_scroll_up(self) -> None:
+        self.query_one("#help-container").scroll_relative(y=-1)
+
+    def action_scroll_top(self) -> None:
+        self.query_one("#help-container").scroll_home()
+
+    def action_scroll_bottom(self) -> None:
+        self.query_one("#help-container").scroll_end()
 
     def compose(self) -> ComposeResult:
         with VerticalScroll(id="help-container"):

--- a/tests/test_help_overlay.py
+++ b/tests/test_help_overlay.py
@@ -1,0 +1,78 @@
+"""Tests for help overlay scrolling with j/k/g/G keys."""
+
+import pytest
+from textual.app import App, ComposeResult
+
+from tenortui.widgets.help_overlay import HelpOverlay
+
+
+class HelpScrollApp(App):
+    BINDINGS = [("question_mark", "help", "Help")]
+
+    def compose(self) -> ComposeResult:
+        yield from ()
+
+    def action_help(self) -> None:
+        self.push_screen(HelpOverlay())
+
+
+@pytest.mark.asyncio
+async def test_j_scrolls_down():
+    """Pressing j scrolls the help overlay down."""
+    app = HelpScrollApp()
+    async with app.run_test(size=(80, 10)) as pilot:
+        await pilot.press("question_mark")
+        container = app.screen.query_one("#help-container")
+        assert container.scroll_offset.y == 0
+        await pilot.press("j")
+        await pilot.pause()
+        assert container.scroll_offset.y > 0
+
+
+@pytest.mark.asyncio
+async def test_k_scrolls_up():
+    """Pressing k scrolls the help overlay up."""
+    app = HelpScrollApp()
+    async with app.run_test(size=(80, 10)) as pilot:
+        await pilot.press("question_mark")
+        container = app.screen.query_one("#help-container")
+        # Scroll down first so we can scroll back up
+        await pilot.press("j")
+        await pilot.press("j")
+        await pilot.pause()
+        scrolled = container.scroll_offset.y
+        await pilot.press("k")
+        await pilot.pause()
+        assert container.scroll_offset.y < scrolled
+
+
+@pytest.mark.asyncio
+async def test_g_scrolls_to_top():
+    """Pressing g scrolls the help overlay to the top."""
+    app = HelpScrollApp()
+    async with app.run_test(size=(80, 10)) as pilot:
+        await pilot.press("question_mark")
+        container = app.screen.query_one("#help-container")
+        # Scroll down first
+        await pilot.press("j")
+        await pilot.press("j")
+        await pilot.press("j")
+        await pilot.pause()
+        assert container.scroll_offset.y > 0
+        await pilot.press("g")
+        await pilot.pause()
+        assert container.scroll_offset.y == 0
+
+
+@pytest.mark.asyncio
+async def test_G_scrolls_to_bottom():
+    """Pressing G scrolls the help overlay to the bottom."""
+    app = HelpScrollApp()
+    async with app.run_test(size=(80, 10)) as pilot:
+        await pilot.press("question_mark")
+        container = app.screen.query_one("#help-container")
+        await pilot.press("G")
+        await pilot.pause()
+        assert container.scroll_offset.y > 0
+        max_y = container.virtual_size.height - container.size.height
+        assert container.scroll_offset.y >= max_y


### PR DESCRIPTION
## Summary
- Add vim-style scrolling keys (j/k/g/G) to the help overlay modal
- j/k scrolls one line at a time, g/G jumps to top/bottom

## Test plan
- [x] `test_j_scrolls_down` — verifies j moves scroll position down
- [x] `test_k_scrolls_up` — verifies k moves scroll position up
- [x] `test_g_scrolls_to_top` — verifies g resets scroll to top
- [x] `test_G_scrolls_to_bottom` — verifies G scrolls to end

Closes #26

*Co-authored by Claude*