### PR TITLE
feat: add bid-ask spread quality indicator column

### DIFF
--- a/src/tenortui/app.py
+++ b/src/tenortui/app.py
@@ -7,7 +7,7 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
 
-from tenortui.config import load_config
+from tenortui.config import SpreadThresholds, load_config
 from tenortui.exceptions import ConfigError, ProviderError, SymbolNotFoundError
 from tenortui.history import load_history, add_to_history
 from tenortui.market_hours import MarketState, get_market_state
@@ -37,9 +37,10 @@ class TenorTUI(App):
     DEFAULT_REFRESH_INTERVAL = 60  # seconds
     OFF_HOURS_REFRESH_INTERVAL = 300  # 5 minutes when market closed
 
-    def __init__(self, provider):
+    def __init__(self, provider, spread_thresholds: SpreadThresholds | None = None):
         super().__init__()
         self._provider = provider
+        self._spread_thresholds = spread_thresholds or SpreadThresholds()
         self._current_symbol: str | None = None
         self._current_expiration: str | None = None
         self._current_price: float | None = None
@@ -298,7 +299,9 @@ class TenorTUI(App):
                 chain = await asyncio.to_thread(
                     self._provider.get_chain, symbol, expirations[0]
                 )
-                await chain_table.display_chain(chain, self._current_price)
+                await chain_table.display_chain(
+                    chain, self._current_price, self._spread_thresholds
+                )
             else:
                 await chain_table.show_message(f"No options available for {symbol}")
         except ProviderError as e:
@@ -321,7 +324,9 @@ class TenorTUI(App):
             chain = await asyncio.to_thread(
                 self._provider.get_chain, symbol, expiration
             )
-            await chain_table.display_chain(chain, self._current_price)
+            await chain_table.display_chain(
+                chain, self._current_price, self._spread_thresholds
+            )
         except ProviderError as e:
             await chain_table.show_message(str(e))
 
@@ -365,5 +370,5 @@ def main() -> None:
     else:
         provider = provider_cls()
 
-    app = TenorTUI(provider=provider)
+    app = TenorTUI(provider=provider, spread_thresholds=config.spread_thresholds)
     app.run()

--- a/src/tenortui/config.py
+++ b/src/tenortui/config.py
@@ -28,9 +28,27 @@ def resolve_config_path(
 
 
 @dataclass
+class SpreadThresholds:
+    tight: float = 5.0
+    moderate: float = 15.0
+
+
+@dataclass
 class AppConfig:
     provider_name: str
     provider_config: dict = field(default_factory=dict)
+    spread_thresholds: SpreadThresholds = field(default_factory=SpreadThresholds)
+
+
+def _parse_spread_thresholds(raw: dict) -> SpreadThresholds:
+    """Parse spread_thresholds from raw config, falling back to defaults."""
+    section = raw.get("spread_thresholds")
+    if not isinstance(section, dict):
+        return SpreadThresholds()
+    return SpreadThresholds(
+        tight=float(section.get("tight", 5.0)),
+        moderate=float(section.get("moderate", 15.0)),
+    )
 
 
 def load_config(
@@ -40,6 +58,7 @@ def load_config(
     if config_path is None:
         config_path = resolve_config_path()
     raw = _read_config_file(config_path)
+    spread_thresholds = _parse_spread_thresholds(raw)
 
     if provider_override:
         provider_name = provider_override
@@ -51,7 +70,11 @@ def load_config(
                 f"Unknown provider '{provider_name}'. "
                 f"Available: {', '.join(sorted(KNOWN_PROVIDERS))}"
             )
-        return AppConfig(provider_name=provider_name, provider_config=provider_config)
+        return AppConfig(
+            provider_name=provider_name,
+            provider_config=provider_config,
+            spread_thresholds=spread_thresholds,
+        )
 
     if "default" in raw:
         provider_name = raw["default"]
@@ -73,7 +96,11 @@ def load_config(
                 f"Provider '{provider_name}' requires '{req_field}' in ~/.config/tenor/config.yaml"
             )
 
-    return AppConfig(provider_name=provider_name, provider_config=provider_config)
+    return AppConfig(
+        provider_name=provider_name,
+        provider_config=provider_config,
+        spread_thresholds=spread_thresholds,
+    )
 
 
 def _read_config_file(path: Path) -> dict:

--- a/src/tenortui/models.py
+++ b/src/tenortui/models.py
@@ -34,6 +34,13 @@ class OptionContract:
         return (self.bid + self.ask) / 2
 
     @property
+    def spread_percent(self) -> float:
+        """Bid-ask spread as percentage of mid price."""
+        if self.mid == 0:
+            return 0.0
+        return ((self.ask - self.bid) / self.mid) * 100
+
+    @property
     def has_greeks(self) -> bool:
         return self.delta is not None
 

--- a/src/tenortui/widgets/chain_table.py
+++ b/src/tenortui/widgets/chain_table.py
@@ -1,14 +1,17 @@
+from rich.text import Text
 from textual.app import ComposeResult
 from textual.containers import VerticalScroll
 from textual.widget import Widget
 from textual.widgets import DataTable, Static
 
+from tenortui.config import SpreadThresholds
 from tenortui.models import OptionsChain
 
 BASE_COLUMNS = [
     ("Strike", 10),
     ("Bid", 8),
     ("Ask", 8),
+    ("Spread", 8),
     ("Mid", 8),
     ("Last", 8),
     ("Vol", 8),
@@ -23,6 +26,8 @@ GREEK_COLUMNS = [
     ("Vega", 8),
     ("Rho", 8),
 ]
+
+DEFAULT_SPREAD_THRESHOLDS = SpreadThresholds()
 
 
 class ChainTable(Widget):
@@ -63,10 +68,14 @@ class ChainTable(Widget):
         )
 
     async def display_chain(
-        self, chain: OptionsChain, current_price: float | None = None
+        self,
+        chain: OptionsChain,
+        current_price: float | None = None,
+        spread_thresholds: SpreadThresholds | None = None,
     ) -> None:
         show_greeks = any(c.has_greeks for c in chain.calls + chain.puts)
         columns = BASE_COLUMNS + (GREEK_COLUMNS if show_greeks else [])
+        thresholds = spread_thresholds or DEFAULT_SPREAD_THRESHOLDS
 
         container = self.query_one(VerticalScroll)
         await container.remove_children()
@@ -80,9 +89,11 @@ class ChainTable(Widget):
         await container.mount(puts_table)
 
         calls_atm = self._populate_table(
-            calls_table, columns, chain.calls, current_price
+            calls_table, columns, chain.calls, current_price, thresholds
         )
-        puts_atm = self._populate_table(puts_table, columns, chain.puts, current_price)
+        puts_atm = self._populate_table(
+            puts_table, columns, chain.puts, current_price, thresholds
+        )
 
         # Place cursor on ATM row, then center it in the viewport after render
         if calls_atm is not None:
@@ -92,7 +103,19 @@ class ChainTable(Widget):
             puts_table.move_cursor(row=puts_atm)
             self._center_on_row(puts_table, puts_atm)
 
-    def _populate_table(self, table, columns, contracts, current_price) -> int | None:
+    def _format_spread(self, spread_pct: float, thresholds: SpreadThresholds) -> Text:
+        """Format spread percentage with color based on thresholds."""
+        if spread_pct < thresholds.tight:
+            color = "green"
+        elif spread_pct < thresholds.moderate:
+            color = "yellow"
+        else:
+            color = "red"
+        return Text(f"{spread_pct:.1f}%", style=color)
+
+    def _populate_table(
+        self, table, columns, contracts, current_price, thresholds
+    ) -> int | None:
         """Populate table and return the ATM row index (or None)."""
         for col_name, _width in columns:
             table.add_column(col_name, key=col_name.lower())
@@ -112,6 +135,7 @@ class ChainTable(Widget):
                 f"{contract.strike:.2f}",
                 f"{contract.bid:.2f}",
                 f"{contract.ask:.2f}",
+                self._format_spread(contract.spread_percent, thresholds),
                 f"{contract.mid:.2f}",
                 f"{contract.last_price:.2f}",
                 f"{contract.volume:,}",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tenortui.config import load_config, resolve_config_path
+from tenortui.config import SpreadThresholds, load_config, resolve_config_path
 from tenortui.exceptions import ConfigError
 
 
@@ -91,3 +91,41 @@ class TestConfigPathMigration:
         old_path = tmp_path / ".tenorrc"
         resolved = resolve_config_path(new_path=new_path, legacy_path=old_path)
         assert resolved == new_path
+
+
+class TestSpreadThresholds:
+    def test_defaults_when_no_config(self, tmp_path):
+        config = load_config(config_path=tmp_path / "nonexistent")
+        assert config.spread_thresholds.tight == 5.0
+        assert config.spread_thresholds.moderate == 15.0
+
+    def test_custom_thresholds(self, tmp_path):
+        rc = tmp_path / "config.yaml"
+        rc.write_text(
+            "---\ndefault: yahoo\nspread_thresholds:\n  tight: 3.0\n  moderate: 10.0\n"
+        )
+        config = load_config(config_path=rc)
+        assert config.spread_thresholds.tight == 3.0
+        assert config.spread_thresholds.moderate == 10.0
+
+    def test_partial_thresholds_uses_defaults(self, tmp_path):
+        rc = tmp_path / "config.yaml"
+        rc.write_text("---\ndefault: yahoo\nspread_thresholds:\n  tight: 2.0\n")
+        config = load_config(config_path=rc)
+        assert config.spread_thresholds.tight == 2.0
+        assert config.spread_thresholds.moderate == 15.0
+
+    def test_thresholds_with_provider_override(self, tmp_path):
+        rc = tmp_path / "config.yaml"
+        rc.write_text(
+            "---\ndefault: yahoo\nspread_thresholds:\n  tight: 4.0\n  moderate: 12.0\n"
+        )
+        config = load_config(config_path=rc, provider_override="yahoo")
+        assert config.spread_thresholds.tight == 4.0
+        assert config.spread_thresholds.moderate == 12.0
+
+    def test_invalid_spread_thresholds_uses_defaults(self, tmp_path):
+        rc = tmp_path / "config.yaml"
+        rc.write_text("---\ndefault: yahoo\nspread_thresholds: not_a_dict\n")
+        config = load_config(config_path=rc)
+        assert config.spread_thresholds == SpreadThresholds()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -123,6 +123,68 @@ class TestOptionContract:
         assert with_greeks.has_greeks is True
         assert without_greeks.has_greeks is False
 
+    def test_spread_percent(self):
+        c = OptionContract(
+            contract_symbol="AAPL260321C00200000",
+            option_type="call",
+            strike=200.0,
+            bid=14.20,
+            ask=14.50,
+            last_price=14.35,
+            volume=1234,
+            open_interest=8901,
+            implied_volatility=0.32,
+            delta=None,
+            gamma=None,
+            theta=None,
+            vega=None,
+            rho=None,
+        )
+        # spread = (14.50 - 14.20) / 14.35 * 100 = 2.09...%
+        expected = ((14.50 - 14.20) / ((14.20 + 14.50) / 2)) * 100
+        assert abs(c.spread_percent - expected) < 0.001
+
+    def test_spread_percent_zero_mid(self):
+        c = OptionContract(
+            contract_symbol="AAPL260321C00500000",
+            option_type="call",
+            strike=500.0,
+            bid=0.0,
+            ask=0.0,
+            last_price=0.0,
+            volume=0,
+            open_interest=0,
+            implied_volatility=0.0,
+            delta=None,
+            gamma=None,
+            theta=None,
+            vega=None,
+            rho=None,
+        )
+        assert c.spread_percent == 0.0
+
+    def test_spread_percent_wide(self):
+        c = OptionContract(
+            contract_symbol="AAPL260321P00200000",
+            option_type="put",
+            strike=200.0,
+            bid=0.10,
+            ask=0.50,
+            last_price=0.30,
+            volume=10,
+            open_interest=50,
+            implied_volatility=0.50,
+            delta=None,
+            gamma=None,
+            theta=None,
+            vega=None,
+            rho=None,
+        )
+        # spread = (0.50 - 0.10) / 0.30 * 100 = 133.33%
+        expected = ((0.50 - 0.10) / ((0.10 + 0.50) / 2)) * 100
+        assert c.spread_percent > 100.0
+        assert abs(c.spread_percent - expected) < 0.01
+
 
 class TestOptionsChain:
     def test_create_chain(self):

--- a/tests/test_widgets_coverage.py
+++ b/tests/test_widgets_coverage.py
@@ -4,6 +4,7 @@ recently_viewed, expiry_selector, status_bar edge cases."""
 import pytest
 from textual.app import App, ComposeResult
 
+from tenortui.config import SpreadThresholds
 from tenortui.models import OptionContract, OptionsChain, Quote
 from tenortui.widgets.chain_table import ChainTable
 from tenortui.widgets.expiry_selector import ExpirySelector
@@ -128,6 +129,49 @@ async def test_chain_table_display_chain_replaces_previous():
     async with app.run_test():
         await widget.display_chain(chain1, current_price=200.0)
         await widget.display_chain(chain2, current_price=305.0)
+
+
+@pytest.mark.asyncio
+async def test_chain_table_has_spread_column():
+    """ChainTable includes a Spread column in both calls and puts tables."""
+    chain = OptionsChain(
+        symbol="AAPL",
+        expiration="2026-03-21",
+        calls=[_make_contract(200.0), _make_contract(210.0)],
+        puts=[_make_contract(200.0, "put")],
+    )
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        await widget.display_chain(chain, current_price=205.0)
+        from textual.widgets import DataTable
+
+        tables = widget.query(DataTable)
+        for table in tables:
+            col_keys = [col.key.value for col in table.columns.values()]
+            assert "spread" in col_keys
+
+
+@pytest.mark.asyncio
+async def test_chain_table_spread_color_classification():
+    """Spread column uses correct colors for tight/moderate/wide spreads."""
+    widget = ChainTable()
+    thresholds = SpreadThresholds(tight=5.0, moderate=15.0)
+    # With bid=1.0 and ask=1.5, spread = 0.5/1.25*100 = 40% => red
+    spread_text = widget._format_spread(40.0, thresholds)
+    assert spread_text.style == "red"
+    # Tight spread
+    spread_text = widget._format_spread(2.0, thresholds)
+    assert spread_text.style == "green"
+    # Moderate spread
+    spread_text = widget._format_spread(10.0, thresholds)
+    assert spread_text.style == "yellow"
+    # Boundary: exactly at tight threshold => moderate (yellow)
+    spread_text = widget._format_spread(5.0, thresholds)
+    assert spread_text.style == "yellow"
+    # Boundary: exactly at moderate threshold => wide (red)
+    spread_text = widget._format_spread(15.0, thresholds)
+    assert spread_text.style == "red"
 
 
 # --- TickerBar ---


### PR DESCRIPTION
## Summary
- Add color-coded "Spread" column to options chain table (after Ask, before Mid)
- Spread shown as % of mid price: green (<5%), yellow (5-15%), red (>15%)
- Thresholds configurable via `spread_thresholds` in `~/.config/tenor/config.yaml`
- Add `spread_percent` property to `OptionContract` model
- Add `SpreadThresholds` dataclass to config with defaults

## Config example
```yaml
spread_thresholds:
  tight: 3.0
  moderate: 10.0
```

## Test plan
- [x] `test_spread_percent` — spread calculation on normal contracts
- [x] `test_spread_percent_zero_mid` — edge case where mid=0
- [x] `test_spread_percent_wide` — wide spread calculation
- [x] `test_defaults_when_no_config` — default thresholds without config
- [x] `test_custom_thresholds` — custom thresholds from config
- [x] `test_partial_thresholds_uses_defaults` — partial config falls back
- [x] `test_thresholds_with_provider_override` — works with CLI override
- [x] `test_invalid_spread_thresholds_uses_defaults` — invalid config uses defaults
- [x] `test_chain_table_has_spread_column` — Spread column present in both tables
- [x] `test_chain_table_spread_color_classification` — correct colors at boundaries

Closes #12

*Co-authored by Claude*