### PR TITLE
feat: fetch live risk-free rate from FRED Treasury API

### DIFF
--- a/src/tenortui/app.py
+++ b/src/tenortui/app.py
@@ -44,6 +44,7 @@ class TenorTUI(App):
         provider,
         spread_thresholds: SpreadThresholds | None = None,
         greeks_config: GreeksConfig | None = None,
+        fred_api_key: str | None = None,
     ):
         super().__init__()
         self._provider = provider
@@ -59,7 +60,10 @@ class TenorTUI(App):
         self._auto_refresh_countdown: int = 0
         self._refresh_timer = None
         self._countdown_timer = None
-        rate, is_live = get_risk_free_rate(fallback=self._greeks_config.risk_free_rate)
+        rate, is_live = get_risk_free_rate(
+            fallback=self._greeks_config.risk_free_rate,
+            fred_api_key=fred_api_key,
+        )
         self._risk_free_rate = rate
         self._risk_free_rate_is_live = is_live
 
@@ -420,5 +424,6 @@ def main() -> None:
         provider=provider,
         spread_thresholds=config.spread_thresholds,
         greeks_config=config.greeks,
+        fred_api_key=config.fred_api_key,
     )
     app.run()

--- a/src/tenortui/app.py
+++ b/src/tenortui/app.py
@@ -13,6 +13,7 @@ from tenortui.history import load_history, add_to_history
 from tenortui.market_hours import MarketState, get_market_state
 from tenortui.providers import PROVIDERS
 from tenortui.providers.yahoo import batch_quotes, fetch_fundamentals
+from tenortui.risk_free_rate import get_risk_free_rate
 from tenortui.widgets.chain_table import ChainTable
 from tenortui.widgets.fundamentals_bar import FundamentalsBar
 from tenortui.widgets.command_palette import CommandPalette
@@ -58,6 +59,9 @@ class TenorTUI(App):
         self._auto_refresh_countdown: int = 0
         self._refresh_timer = None
         self._countdown_timer = None
+        rate, is_live = get_risk_free_rate(fallback=self._greeks_config.risk_free_rate)
+        self._risk_free_rate = rate
+        self._risk_free_rate_is_live = is_live
 
     def compose(self) -> ComposeResult:
         yield TickerBar()
@@ -78,6 +82,9 @@ class TenorTUI(App):
         else:
             recently_viewed.display = False
         self._update_market_display()
+        self.query_one(StatusBar).update_rate_display(
+            self._risk_free_rate, self._risk_free_rate_is_live
+        )
         # Update market state display every 60s
         self.set_interval(60, self._update_market_display)
 
@@ -322,7 +329,7 @@ class TenorTUI(App):
                         chain=chain,
                         spot=self._current_price,
                         expiration=expirations[0],
-                        risk_free_rate=self._greeks_config.risk_free_rate,
+                        risk_free_rate=self._risk_free_rate,
                         dividend_yield=self._current_dividend_yield,
                     )
                 await chain_table.display_chain(
@@ -360,7 +367,7 @@ class TenorTUI(App):
                     chain=chain,
                     spot=self._current_price,
                     expiration=expiration,
-                    risk_free_rate=self._greeks_config.risk_free_rate,
+                    risk_free_rate=self._risk_free_rate,
                     dividend_yield=self._current_dividend_yield,
                 )
             await chain_table.display_chain(

--- a/src/tenortui/config.py
+++ b/src/tenortui/config.py
@@ -45,6 +45,7 @@ class AppConfig:
     provider_config: dict = field(default_factory=dict)
     spread_thresholds: SpreadThresholds = field(default_factory=SpreadThresholds)
     greeks: GreeksConfig = field(default_factory=GreeksConfig)
+    fred_api_key: str | None = None
 
 
 def _parse_greeks_config(provider_name: str, provider_config: dict) -> GreeksConfig:
@@ -79,6 +80,7 @@ def load_config(
         config_path = resolve_config_path()
     raw = _read_config_file(config_path)
     spread_thresholds = _parse_spread_thresholds(raw)
+    fred_api_key = raw.get("fred_api_key")
 
     if provider_override:
         provider_name = provider_override
@@ -95,6 +97,7 @@ def load_config(
             provider_config=provider_config,
             spread_thresholds=spread_thresholds,
             greeks=_parse_greeks_config(provider_name, provider_config),
+            fred_api_key=fred_api_key,
         )
 
     if "default" in raw:
@@ -122,6 +125,7 @@ def load_config(
         provider_config=provider_config,
         spread_thresholds=spread_thresholds,
         greeks=_parse_greeks_config(provider_name, provider_config),
+        fred_api_key=fred_api_key,
     )
 
 

--- a/src/tenortui/risk_free_rate.py
+++ b/src/tenortui/risk_free_rate.py
@@ -2,23 +2,27 @@ import requests
 
 FRED_URL = "https://api.stlouisfed.org/fred/series/observations"
 FRED_SERIES = "DTB3"
-FRED_API_KEY = "DEMO_KEY"
 
 _cached_rate: float | None = None
 _cached_is_live: bool = False
 
 
-def get_risk_free_rate(fallback: float = 0.05) -> tuple[float, bool]:
+def get_risk_free_rate(
+    fallback: float = 0.05, fred_api_key: str | None = None
+) -> tuple[float, bool]:
     global _cached_rate, _cached_is_live
     if _cached_rate is not None:
         return _cached_rate, _cached_is_live
+
+    if not fred_api_key:
+        return fallback, False
 
     try:
         resp = requests.get(
             FRED_URL,
             params={
                 "series_id": FRED_SERIES,
-                "api_key": FRED_API_KEY,
+                "api_key": fred_api_key,
                 "file_type": "json",
                 "sort_order": "desc",
                 "limit": 10,

--- a/src/tenortui/risk_free_rate.py
+++ b/src/tenortui/risk_free_rate.py
@@ -1,0 +1,41 @@
+import requests
+
+FRED_URL = "https://api.stlouisfed.org/fred/series/observations"
+FRED_SERIES = "DTB3"
+FRED_API_KEY = "DEMO_KEY"
+
+_cached_rate: float | None = None
+_cached_is_live: bool = False
+
+
+def get_risk_free_rate(fallback: float = 0.05) -> tuple[float, bool]:
+    global _cached_rate, _cached_is_live
+    if _cached_rate is not None:
+        return _cached_rate, _cached_is_live
+
+    try:
+        resp = requests.get(
+            FRED_URL,
+            params={
+                "series_id": FRED_SERIES,
+                "api_key": FRED_API_KEY,
+                "file_type": "json",
+                "sort_order": "desc",
+                "limit": 10,
+            },
+            timeout=5,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        for obs in data.get("observations", []):
+            if obs["value"] == ".":
+                continue
+            rate = float(obs["value"]) / 100.0
+            _cached_rate = rate
+            _cached_is_live = True
+            return rate, True
+
+        return fallback, False
+    except Exception:
+        return fallback, False

--- a/src/tenortui/widgets/status_bar.py
+++ b/src/tenortui/widgets/status_bar.py
@@ -45,6 +45,16 @@ class StatusBar(Widget):
         width: 1fr;
         padding: 0 1;
     }
+    StatusBar .status-rate-live {
+        width: auto;
+        padding: 0 1;
+        color: $success;
+    }
+    StatusBar .status-rate-config {
+        width: auto;
+        padding: 0 1;
+        color: $warning;
+    }
     StatusBar .status-refresh {
         width: auto;
         padding: 0 1;
@@ -65,6 +75,7 @@ class StatusBar(Widget):
         with Horizontal():
             yield Static(self._provider_name, classes="status-provider")
             yield Static("", classes="status-market", id="status-market")
+            yield Static("", classes="status-rate-live", id="status-rate")
             yield Static("? Help", classes="status-keys")
             yield Static("", classes="status-refresh", id="status-refresh")
             yield Static(self._last_refresh, classes="status-time", id="status-time")
@@ -121,6 +132,21 @@ class StatusBar(Widget):
                 widget.update(f"↻ {seconds_until}s")
             else:
                 widget.update("")
+        except Exception:
+            pass
+
+    def update_rate_display(self, rate: float, is_live: bool) -> None:
+        try:
+            widget = self.query_one("#status-rate", Static)
+            pct = f"{rate * 100:.2f}%"
+            if is_live:
+                widget.update(f"RF: {pct} (live)")
+                widget.remove_class("status-rate-config")
+                widget.add_class("status-rate-live")
+            else:
+                widget.update(f"RF: {pct} (config)")
+                widget.remove_class("status-rate-live")
+                widget.add_class("status-rate-config")
         except Exception:
             pass
 

--- a/tests/test_risk_free_rate.py
+++ b/tests/test_risk_free_rate.py
@@ -1,0 +1,98 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+import tenortui.risk_free_rate as rfr_module
+from tenortui.risk_free_rate import get_risk_free_rate
+
+
+@pytest.fixture(autouse=True)
+def reset_cache():
+    rfr_module._cached_rate = None
+    rfr_module._cached_is_live = False
+    yield
+
+
+def _mock_response(observations):
+    resp = MagicMock()
+    resp.json.return_value = {"observations": observations}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+class TestGetRiskFreeRate:
+    def test_successful_fetch(self):
+        resp = _mock_response([{"date": "2026-03-20", "value": "4.32"}])
+        with patch("tenortui.risk_free_rate.requests.get", return_value=resp):
+            rate, is_live = get_risk_free_rate()
+        assert rate == pytest.approx(0.0432)
+        assert is_live is True
+
+    def test_skips_missing_data(self):
+        resp = _mock_response(
+            [
+                {"date": "2026-03-20", "value": "."},
+                {"date": "2026-03-19", "value": "4.30"},
+            ]
+        )
+        with patch("tenortui.risk_free_rate.requests.get", return_value=resp):
+            rate, is_live = get_risk_free_rate()
+        assert rate == pytest.approx(0.0430)
+        assert is_live is True
+
+    def test_api_failure_returns_fallback(self):
+        with patch(
+            "tenortui.risk_free_rate.requests.get", side_effect=Exception("timeout")
+        ):
+            rate, is_live = get_risk_free_rate(fallback=0.05)
+        assert rate == 0.05
+        assert is_live is False
+
+    def test_caching(self):
+        resp = _mock_response([{"date": "2026-03-20", "value": "4.32"}])
+        with patch(
+            "tenortui.risk_free_rate.requests.get", return_value=resp
+        ) as mock_get:
+            get_risk_free_rate()
+            get_risk_free_rate()
+            assert mock_get.call_count == 1
+
+    def test_empty_observations_returns_fallback(self):
+        resp = _mock_response([])
+        with patch("tenortui.risk_free_rate.requests.get", return_value=resp):
+            rate, is_live = get_risk_free_rate(fallback=0.03)
+        assert rate == 0.03
+        assert is_live is False
+
+    def test_all_missing_data_returns_fallback(self):
+        resp = _mock_response(
+            [
+                {"date": "2026-03-20", "value": "."},
+                {"date": "2026-03-19", "value": "."},
+            ]
+        )
+        with patch("tenortui.risk_free_rate.requests.get", return_value=resp):
+            rate, is_live = get_risk_free_rate(fallback=0.05)
+        assert rate == 0.05
+        assert is_live is False
+
+    def test_rate_conversion(self):
+        resp = _mock_response([{"date": "2026-03-20", "value": "5.00"}])
+        with patch("tenortui.risk_free_rate.requests.get", return_value=resp):
+            rate, is_live = get_risk_free_rate()
+        assert rate == pytest.approx(0.05)
+
+    def test_custom_fallback(self):
+        with patch(
+            "tenortui.risk_free_rate.requests.get", side_effect=Exception("err")
+        ):
+            rate, is_live = get_risk_free_rate(fallback=0.04)
+        assert rate == 0.04
+        assert is_live is False
+
+    def test_http_error_returns_fallback(self):
+        resp = MagicMock()
+        resp.raise_for_status.side_effect = Exception("HTTP 500")
+        with patch("tenortui.risk_free_rate.requests.get", return_value=resp):
+            rate, is_live = get_risk_free_rate()
+        assert rate == 0.05
+        assert is_live is False

--- a/tests/test_risk_free_rate.py
+++ b/tests/test_risk_free_rate.py
@@ -4,6 +4,8 @@ from unittest.mock import patch, MagicMock
 import tenortui.risk_free_rate as rfr_module
 from tenortui.risk_free_rate import get_risk_free_rate
 
+TEST_KEY = "test_api_key_32chars_placeholder_"
+
 
 @pytest.fixture(autouse=True)
 def reset_cache():
@@ -23,7 +25,7 @@ class TestGetRiskFreeRate:
     def test_successful_fetch(self):
         resp = _mock_response([{"date": "2026-03-20", "value": "4.32"}])
         with patch("tenortui.risk_free_rate.requests.get", return_value=resp):
-            rate, is_live = get_risk_free_rate()
+            rate, is_live = get_risk_free_rate(fred_api_key=TEST_KEY)
         assert rate == pytest.approx(0.0432)
         assert is_live is True
 
@@ -35,7 +37,7 @@ class TestGetRiskFreeRate:
             ]
         )
         with patch("tenortui.risk_free_rate.requests.get", return_value=resp):
-            rate, is_live = get_risk_free_rate()
+            rate, is_live = get_risk_free_rate(fred_api_key=TEST_KEY)
         assert rate == pytest.approx(0.0430)
         assert is_live is True
 
@@ -43,7 +45,7 @@ class TestGetRiskFreeRate:
         with patch(
             "tenortui.risk_free_rate.requests.get", side_effect=Exception("timeout")
         ):
-            rate, is_live = get_risk_free_rate(fallback=0.05)
+            rate, is_live = get_risk_free_rate(fallback=0.05, fred_api_key=TEST_KEY)
         assert rate == 0.05
         assert is_live is False
 
@@ -52,14 +54,14 @@ class TestGetRiskFreeRate:
         with patch(
             "tenortui.risk_free_rate.requests.get", return_value=resp
         ) as mock_get:
-            get_risk_free_rate()
-            get_risk_free_rate()
+            get_risk_free_rate(fred_api_key=TEST_KEY)
+            get_risk_free_rate(fred_api_key=TEST_KEY)
             assert mock_get.call_count == 1
 
     def test_empty_observations_returns_fallback(self):
         resp = _mock_response([])
         with patch("tenortui.risk_free_rate.requests.get", return_value=resp):
-            rate, is_live = get_risk_free_rate(fallback=0.03)
+            rate, is_live = get_risk_free_rate(fallback=0.03, fred_api_key=TEST_KEY)
         assert rate == 0.03
         assert is_live is False
 
@@ -71,21 +73,21 @@ class TestGetRiskFreeRate:
             ]
         )
         with patch("tenortui.risk_free_rate.requests.get", return_value=resp):
-            rate, is_live = get_risk_free_rate(fallback=0.05)
+            rate, is_live = get_risk_free_rate(fallback=0.05, fred_api_key=TEST_KEY)
         assert rate == 0.05
         assert is_live is False
 
     def test_rate_conversion(self):
         resp = _mock_response([{"date": "2026-03-20", "value": "5.00"}])
         with patch("tenortui.risk_free_rate.requests.get", return_value=resp):
-            rate, is_live = get_risk_free_rate()
+            rate, is_live = get_risk_free_rate(fred_api_key=TEST_KEY)
         assert rate == pytest.approx(0.05)
 
     def test_custom_fallback(self):
         with patch(
             "tenortui.risk_free_rate.requests.get", side_effect=Exception("err")
         ):
-            rate, is_live = get_risk_free_rate(fallback=0.04)
+            rate, is_live = get_risk_free_rate(fallback=0.04, fred_api_key=TEST_KEY)
         assert rate == 0.04
         assert is_live is False
 
@@ -93,6 +95,16 @@ class TestGetRiskFreeRate:
         resp = MagicMock()
         resp.raise_for_status.side_effect = Exception("HTTP 500")
         with patch("tenortui.risk_free_rate.requests.get", return_value=resp):
-            rate, is_live = get_risk_free_rate()
+            rate, is_live = get_risk_free_rate(fred_api_key=TEST_KEY)
         assert rate == 0.05
+        assert is_live is False
+
+    def test_no_api_key_returns_fallback(self):
+        rate, is_live = get_risk_free_rate(fallback=0.05)
+        assert rate == 0.05
+        assert is_live is False
+
+    def test_none_api_key_returns_fallback(self):
+        rate, is_live = get_risk_free_rate(fallback=0.03, fred_api_key=None)
+        assert rate == 0.03
         assert is_live is False


### PR DESCRIPTION
## Summary
- Fetches 3-month T-bill rate (DTB3) from FRED API on startup for Greeks calculations
- Caches rate for session duration, falls back to config default on API failure
- Status bar shows rate source: "RF: X.XX% (live)" in green or "RF: X.XX% (config)" in yellow

## Test plan
- [x] 9 new tests covering FRED fetch, caching, fallback, rate conversion
- [x] All 207 existing tests pass
- [x] Lint and format clean

Closes #33

*Co-authored by Claude*