### PR TITLE
feat: add --config-help flag for configuration options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Provider methods are synchronous — the app wraps them with `asyncio.to_thread(
 
 ### Configuration
 
-`config.py` loads YAML from `~/.config/tenor/config.yaml` (falls back to `~/.tenorrc`). Provider can be overridden via `--provider` CLI flag. Each provider declares required fields in `PROVIDER_REQUIRED_FIELDS`.
+`config.py` loads YAML from `~/.config/tenor/config.yaml` (falls back to `~/.tenorrc`). Provider can be overridden via `--provider` CLI flag. Each provider declares required fields in `PROVIDER_REQUIRED_FIELDS`. All config options are registered in the `CONFIG_OPTIONS` list in `config.py` — when adding or modifying config options, update this registry to keep `--config-help` output in sync.
 
 ### History
 

--- a/src/tenortui/app.py
+++ b/src/tenortui/app.py
@@ -7,7 +7,12 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
 
-from tenortui.config import GreeksConfig, SpreadThresholds, load_config
+from tenortui.config import (
+    GreeksConfig,
+    SpreadThresholds,
+    load_config,
+    print_config_help,
+)
 from tenortui.exceptions import ConfigError, ProviderError, SymbolNotFoundError
 from tenortui.history import load_history, add_to_history
 from tenortui.market_hours import MarketState, get_market_state
@@ -387,11 +392,20 @@ def _parse_args() -> argparse.Namespace:
         default=None,
         help="Data provider to use (overrides ~/.tenorrc)",
     )
+    parser.add_argument(
+        "--config-help",
+        action="store_true",
+        help="Show all configuration options and exit",
+    )
     return parser.parse_args()
 
 
 def main() -> None:
     args = _parse_args()
+
+    if args.config_help:
+        print_config_help()
+        sys.exit(0)
 
     try:
         config = load_config(provider_override=args.provider)

--- a/src/tenortui/config.py
+++ b/src/tenortui/config.py
@@ -125,6 +125,140 @@ def load_config(
     )
 
 
+@dataclass
+class ConfigOption:
+    key: str
+    type_name: str
+    default: str
+    description: str
+    condition: str = ""
+
+
+CONFIG_OPTIONS: list[ConfigOption] = [
+    ConfigOption(
+        key="default",
+        type_name="str",
+        default="yahoo",
+        description="Default data provider. Options: yahoo, tradier.",
+    ),
+    ConfigOption(
+        key="yahoo.greeks.enabled",
+        type_name="bool",
+        default="false",
+        description="Enable client-side Greeks calculation using Black-Scholes/Binomial models.",
+        condition="Only when provider is yahoo.",
+    ),
+    ConfigOption(
+        key="yahoo.greeks.risk_free_rate",
+        type_name="float",
+        default="0.05",
+        description="Risk-free interest rate for Greeks calculation (decimal, e.g. 0.05 = 5%). Used as fallback when live FRED rate is unavailable.",
+        condition="Only when yahoo.greeks.enabled is true.",
+    ),
+    ConfigOption(
+        key="tradier.api_key",
+        type_name="str",
+        default="required",
+        description="Tradier API key for authentication.",
+        condition="Required when provider is tradier.",
+    ),
+    ConfigOption(
+        key="tradier.sandbox",
+        type_name="bool",
+        default="false",
+        description="Use Tradier sandbox API endpoint instead of production.",
+        condition="Only when provider is tradier.",
+    ),
+    ConfigOption(
+        key="spread_thresholds.tight",
+        type_name="float",
+        default="5.0",
+        description="Bid-ask spread percentage threshold for tight spread highlighting (green).",
+    ),
+    ConfigOption(
+        key="spread_thresholds.moderate",
+        type_name="float",
+        default="15.0",
+        description="Bid-ask spread percentage threshold for moderate spread highlighting (yellow). Spreads above this are red.",
+    ),
+]
+
+
+def print_config_help(config_path: Path | None = None) -> None:
+    if config_path is None:
+        config_path = resolve_config_path()
+    exists = config_path.exists()
+
+    lines = [
+        "TenorTUI Configuration Help",
+        "=" * 28,
+        "",
+        "Config file: ~/.config/tenor/config.yaml",
+    ]
+    if exists:
+        lines.append(f"Active config: {config_path} (exists)")
+    else:
+        lines.append(f"Active config: {config_path} (not found, using defaults)")
+    lines.append("")
+    lines.append("Options:")
+    lines.append("-" * 8)
+    lines.append("")
+
+    # Group options by prefix for indented display
+    current_section: list[str] = []
+    for opt in CONFIG_OPTIONS:
+        parts = opt.key.split(".")
+        if len(parts) == 1:
+            # Top-level option
+            current_section = []
+            default_str = (
+                f'default: "{opt.default}"'
+                if opt.type_name == "str"
+                else f"default: {opt.default}"
+            )
+            lines.append(f"{opt.key} ({opt.type_name}, {default_str})")
+            lines.append(f"  {opt.description}")
+            if opt.condition:
+                lines.append(f"  {opt.condition}")
+            lines.append("")
+        else:
+            # Nested option — show section headers as needed
+            section_parts = parts[:-1]
+            leaf = parts[-1]
+            indent = ""
+            for i, section in enumerate(section_parts):
+                if i >= len(current_section) or current_section[i] != section:
+                    indent = "  " * i
+                    lines.append(f"{indent}{section}:")
+                    current_section = section_parts[: i + 1]
+            indent = "  " * len(section_parts)
+            default_str = (
+                f'default: "{opt.default}"'
+                if opt.type_name == "str"
+                else f"default: {opt.default}"
+            )
+            if opt.default == "required":
+                default_str = "required"
+            lines.append(f"{indent}{leaf} ({opt.type_name}, {default_str})")
+            lines.append(f"{indent}  {opt.description}")
+            if opt.condition:
+                lines.append(f"{indent}  {opt.condition}")
+            lines.append("")
+
+    lines.append("Example config:")
+    lines.append("-" * 15)
+    lines.append("default: yahoo")
+    lines.append("yahoo:")
+    lines.append("  greeks:")
+    lines.append("    enabled: true")
+    lines.append("    risk_free_rate: 0.04")
+    lines.append("spread_thresholds:")
+    lines.append("  tight: 3.0")
+    lines.append("  moderate: 10.0")
+
+    print("\n".join(lines))
+
+
 def _read_config_file(path: Path) -> dict:
     if not path.exists():
         return {}

--- a/tests/test_config_help.py
+++ b/tests/test_config_help.py
@@ -1,0 +1,110 @@
+import io
+from contextlib import redirect_stdout
+
+from tenortui.config import CONFIG_OPTIONS, print_config_help
+
+
+EXPECTED_KEYS = [
+    "default",
+    "yahoo.greeks.enabled",
+    "yahoo.greeks.risk_free_rate",
+    "tradier.api_key",
+    "tradier.sandbox",
+    "spread_thresholds.tight",
+    "spread_thresholds.moderate",
+]
+
+
+class TestConfigOptions:
+    def test_all_expected_keys_present(self):
+        keys = [opt.key for opt in CONFIG_OPTIONS]
+        for expected in EXPECTED_KEYS:
+            assert expected in keys, f"Missing config option: {expected}"
+
+    def test_no_empty_descriptions(self):
+        for opt in CONFIG_OPTIONS:
+            assert opt.description, f"Empty description for {opt.key}"
+
+    def test_no_empty_types(self):
+        for opt in CONFIG_OPTIONS:
+            assert opt.type_name, f"Empty type for {opt.key}"
+
+    def test_no_empty_defaults(self):
+        for opt in CONFIG_OPTIONS:
+            assert opt.default, f"Empty default for {opt.key}"
+
+
+class TestPrintConfigHelp:
+    def _capture_output(self, config_path=None):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            print_config_help(config_path=config_path)
+        return buf.getvalue()
+
+    def test_header_present(self):
+        output = self._capture_output()
+        assert "TenorTUI Configuration Help" in output
+
+    def test_all_option_keys_in_output(self):
+        output = self._capture_output()
+        for key in EXPECTED_KEYS:
+            leaf = key.split(".")[-1]
+            assert leaf in output, f"Option '{key}' leaf '{leaf}' not in output"
+
+    def test_example_config_present(self):
+        output = self._capture_output()
+        assert "Example config:" in output
+        assert "default: yahoo" in output
+
+    def test_config_path_shown(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        output = self._capture_output(config_path=cfg)
+        assert str(cfg) in output
+
+    def test_config_exists_status(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("---\n")
+        output = self._capture_output(config_path=cfg)
+        assert "(exists)" in output
+
+    def test_config_not_found_status(self, tmp_path):
+        cfg = tmp_path / "nonexistent.yaml"
+        output = self._capture_output(config_path=cfg)
+        assert "(not found, using defaults)" in output
+
+    def test_sections_indented(self):
+        output = self._capture_output()
+        assert "yahoo:" in output
+        assert "tradier:" in output
+        assert "spread_thresholds:" in output
+
+    def test_conditions_shown(self):
+        output = self._capture_output()
+        assert "Only when provider is yahoo" in output
+        assert "Required when provider is tradier" in output
+
+
+class TestConfigHelpArgparse:
+    def test_config_help_flag_recognized(self):
+        from tenortui.app import _parse_args
+        import sys
+
+        original = sys.argv
+        sys.argv = ["tenortui", "--config-help"]
+        try:
+            args = _parse_args()
+            assert args.config_help is True
+        finally:
+            sys.argv = original
+
+    def test_default_config_help_is_false(self):
+        from tenortui.app import _parse_args
+        import sys
+
+        original = sys.argv
+        sys.argv = ["tenortui"]
+        try:
+            args = _parse_args()
+            assert args.config_help is False
+        finally:
+            sys.argv = original


### PR DESCRIPTION
## Summary
- Adds `CONFIG_OPTIONS` registry in `config.py` documenting all 7 config keys with types, defaults, descriptions, and conditions
- `--config-help` CLI flag prints formatted help and exits
- Shows active config file path and whether it exists
- CLAUDE.md updated: registry must stay in sync when config options change

## Test plan
- [x] 14 new tests covering registry completeness, output format, argparse, config path display
- [x] All 212 tests pass (198 existing + 14 new)
- [x] Lint and format clean

Closes #34

*Co-authored by Claude*