### PR TITLE
fix: keep focus on expiry tabs when switching expirations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: python -m pytest
+        entry: poetry run python -m pytest
         language: system
         stages: [pre-push]
         always_run: true

--- a/src/tenortui/app.py
+++ b/src/tenortui/app.py
@@ -387,7 +387,6 @@ class TenorTUI(App):
 
         chain_table.loading = False
         self.query_one(StatusBar).update_refresh_time()
-        self._focus_first_table()
 
 
 def _parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## Summary
- Removed `_focus_first_table()` call from `_load_chain` so focus stays on expiry tabs when browsing expirations
- Focus still auto-jumps to ATM on initial ticker load via `_load_ticker`
- Fixed pre-push pytest hook to use `poetry run python -m pytest`

## Test plan
- [x] All 223 tests pass
- [x] Pre-push hook now works correctly

*Co-authored by Claude*