### PR TITLE
feat: configurable auto-refresh intervals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,10 +181,24 @@ After pushing a PR, monitor CI status:
 gh pr checks <pr-number> --watch
 ```
 
-- **All passed**: notify user and await instruction to merge
+- **All passed**: notify user, provide the local test command (see below), and await instruction to merge
 - **Failed**: investigate the failure, propose a fix — do NOT merge
 
 Do NOT merge the PR automatically. Wait for explicit user instruction to merge.
+
+### 5a. Provide Local Test Command
+
+After CI passes, give the user a command to test the feature locally in the worktree. Print the command and copy it to clipboard so they can paste it into a separate terminal:
+
+```bash
+# Print the command for the user
+echo "cd <worktree-path> && poetry install && poetry run tenortui"
+
+# Copy to clipboard (note: cd may be stripped by sandbox, so ask the user to run it themselves)
+! echo -n "cd $(pwd) && poetry install && poetry run tenortui" | pbcopy
+```
+
+The `cd` prefix gets stripped by the Claude Code sandbox when using `pbcopy`, so ask the user to run the `!`-prefixed clipboard command themselves.
 
 ### 6. Merge PR
 

--- a/src/tenortui/app.py
+++ b/src/tenortui/app.py
@@ -9,6 +9,7 @@ from textual.containers import Vertical
 
 from tenortui.config import (
     GreeksConfig,
+    RefreshConfig,
     SpreadThresholds,
     load_config,
     print_config_help,
@@ -41,20 +42,19 @@ class TenorTUI(App):
         Binding("ctrl+p", "toggle_auto_refresh", "Pause Refresh", priority=True),
     ]
 
-    DEFAULT_REFRESH_INTERVAL = 60  # seconds
-    OFF_HOURS_REFRESH_INTERVAL = 300  # 5 minutes when market closed
-
     def __init__(
         self,
         provider,
         spread_thresholds: SpreadThresholds | None = None,
         greeks_config: GreeksConfig | None = None,
         fred_api_key: str | None = None,
+        refresh_config: RefreshConfig | None = None,
     ):
         super().__init__()
         self._provider = provider
         self._spread_thresholds = spread_thresholds or SpreadThresholds()
         self._greeks_config = greeks_config or GreeksConfig()
+        self._refresh_config = refresh_config or RefreshConfig()
         self._current_symbol: str | None = None
         self._current_expiration: str | None = None
         self._current_price: float | None = None
@@ -134,11 +134,11 @@ class TenorTUI(App):
         """Get refresh interval based on market state."""
         state = get_market_state()
         if state == MarketState.REGULAR:
-            return self.DEFAULT_REFRESH_INTERVAL
+            return self._refresh_config.regular
         elif state in (MarketState.PRE_MARKET, MarketState.AFTER_HOURS):
-            return self.DEFAULT_REFRESH_INTERVAL * 2  # 2x during extended hours
+            return self._refresh_config.extended
         else:
-            return self.OFF_HOURS_REFRESH_INTERVAL
+            return self._refresh_config.closed
 
     def _start_auto_refresh(self) -> None:
         """Start the auto-refresh timer."""
@@ -438,5 +438,6 @@ def main() -> None:
         spread_thresholds=config.spread_thresholds,
         greeks_config=config.greeks,
         fred_api_key=config.fred_api_key,
+        refresh_config=config.refresh,
     )
     app.run()

--- a/src/tenortui/config.py
+++ b/src/tenortui/config.py
@@ -40,12 +40,20 @@ class GreeksConfig:
 
 
 @dataclass
+class RefreshConfig:
+    regular: int = 60
+    extended: int = 120
+    closed: int = 300
+
+
+@dataclass
 class AppConfig:
     provider_name: str
     provider_config: dict = field(default_factory=dict)
     spread_thresholds: SpreadThresholds = field(default_factory=SpreadThresholds)
     greeks: GreeksConfig = field(default_factory=GreeksConfig)
     fred_api_key: str | None = None
+    refresh: RefreshConfig = field(default_factory=RefreshConfig)
 
 
 def _parse_greeks_config(provider_name: str, provider_config: dict) -> GreeksConfig:
@@ -58,6 +66,18 @@ def _parse_greeks_config(provider_name: str, provider_config: dict) -> GreeksCon
     return GreeksConfig(
         enabled=bool(section.get("enabled", False)),
         risk_free_rate=float(section.get("risk_free_rate", 0.05)),
+    )
+
+
+def _parse_refresh_config(raw: dict) -> RefreshConfig:
+    """Parse refresh intervals from raw config, falling back to defaults."""
+    section = raw.get("refresh")
+    if not isinstance(section, dict):
+        return RefreshConfig()
+    return RefreshConfig(
+        regular=int(section.get("regular", 60)),
+        extended=int(section.get("extended", 120)),
+        closed=int(section.get("closed", 300)),
     )
 
 
@@ -80,6 +100,7 @@ def load_config(
         config_path = resolve_config_path()
     raw = _read_config_file(config_path)
     spread_thresholds = _parse_spread_thresholds(raw)
+    refresh = _parse_refresh_config(raw)
     fred_api_key = raw.get("fred_api_key")
 
     if provider_override:
@@ -98,6 +119,7 @@ def load_config(
             spread_thresholds=spread_thresholds,
             greeks=_parse_greeks_config(provider_name, provider_config),
             fred_api_key=fred_api_key,
+            refresh=refresh,
         )
 
     if "default" in raw:
@@ -126,6 +148,7 @@ def load_config(
         spread_thresholds=spread_thresholds,
         greeks=_parse_greeks_config(provider_name, provider_config),
         fred_api_key=fred_api_key,
+        refresh=refresh,
     )
 
 

--- a/src/tenortui/config.py
+++ b/src/tenortui/config.py
@@ -208,6 +208,24 @@ CONFIG_OPTIONS: list[ConfigOption] = [
         default="15.0",
         description="Bid-ask spread percentage threshold for moderate spread highlighting (yellow). Spreads above this are red.",
     ),
+    ConfigOption(
+        key="refresh.regular",
+        type_name="int",
+        default="60",
+        description="Auto-refresh interval in seconds during regular market hours.",
+    ),
+    ConfigOption(
+        key="refresh.extended",
+        type_name="int",
+        default="120",
+        description="Auto-refresh interval in seconds during pre-market and after-hours.",
+    ),
+    ConfigOption(
+        key="refresh.closed",
+        type_name="int",
+        default="300",
+        description="Auto-refresh interval in seconds when the market is closed.",
+    ),
 ]
 
 
@@ -282,6 +300,10 @@ def print_config_help(config_path: Path | None = None) -> None:
     lines.append("spread_thresholds:")
     lines.append("  tight: 3.0")
     lines.append("  moderate: 10.0")
+    lines.append("refresh:")
+    lines.append("  regular: 5")
+    lines.append("  extended: 30")
+    lines.append("  closed: 300")
 
     print("\n".join(lines))
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,11 @@
 import pytest
 
-from tenortui.config import SpreadThresholds, load_config, resolve_config_path
+from tenortui.config import (
+    RefreshConfig,
+    SpreadThresholds,
+    load_config,
+    resolve_config_path,
+)
 from tenortui.exceptions import ConfigError
 
 
@@ -178,3 +183,45 @@ class TestGreeksConfig:
         rc.write_text("---\ndefault: yahoo\nyahoo:\n  greeks: not_a_dict\n")
         config = load_config(config_path=rc)
         assert config.greeks.enabled is False
+
+
+class TestRefreshConfig:
+    def test_defaults_when_no_config(self, tmp_path):
+        config = load_config(config_path=tmp_path / "nonexistent")
+        assert config.refresh.regular == 60
+        assert config.refresh.extended == 120
+        assert config.refresh.closed == 300
+
+    def test_custom_refresh_intervals(self, tmp_path):
+        rc = tmp_path / "config.yaml"
+        rc.write_text(
+            "---\ndefault: yahoo\nrefresh:\n  regular: 5\n  extended: 30\n  closed: 600\n"
+        )
+        config = load_config(config_path=rc)
+        assert config.refresh.regular == 5
+        assert config.refresh.extended == 30
+        assert config.refresh.closed == 600
+
+    def test_partial_refresh_uses_defaults(self, tmp_path):
+        rc = tmp_path / "config.yaml"
+        rc.write_text("---\ndefault: yahoo\nrefresh:\n  regular: 10\n")
+        config = load_config(config_path=rc)
+        assert config.refresh.regular == 10
+        assert config.refresh.extended == 120
+        assert config.refresh.closed == 300
+
+    def test_invalid_refresh_uses_defaults(self, tmp_path):
+        rc = tmp_path / "config.yaml"
+        rc.write_text("---\ndefault: yahoo\nrefresh: not_a_dict\n")
+        config = load_config(config_path=rc)
+        assert config.refresh == RefreshConfig()
+
+    def test_refresh_with_provider_override(self, tmp_path):
+        rc = tmp_path / "config.yaml"
+        rc.write_text(
+            "---\ndefault: yahoo\nrefresh:\n  regular: 15\n  extended: 45\n  closed: 120\n"
+        )
+        config = load_config(config_path=rc, provider_override="yahoo")
+        assert config.refresh.regular == 15
+        assert config.refresh.extended == 45
+        assert config.refresh.closed == 120

--- a/tests/test_config_help.py
+++ b/tests/test_config_help.py
@@ -12,6 +12,9 @@ EXPECTED_KEYS = [
     "tradier.sandbox",
     "spread_thresholds.tight",
     "spread_thresholds.moderate",
+    "refresh.regular",
+    "refresh.extended",
+    "refresh.closed",
 ]
 
 
@@ -82,6 +85,13 @@ class TestPrintConfigHelp:
         output = self._capture_output()
         assert "Only when provider is yahoo" in output
         assert "Required when provider is tradier" in output
+
+    def test_refresh_section_in_output(self):
+        output = self._capture_output()
+        assert "refresh:" in output
+        assert "regular" in output
+        assert "extended" in output
+        assert "closed" in output
 
 
 class TestConfigHelpArgparse:


### PR DESCRIPTION
## Summary
- Add `RefreshConfig` dataclass with `regular`, `extended`, and `closed` fields (defaults: 60s/120s/300s) parsed from `refresh:` section in `config.yaml`
- Wire config into `TenorTUI._get_refresh_interval()`, replacing hardcoded constants
- Register all 3 options in `CONFIG_OPTIONS` so they appear in `--config-help`

Closes #39

## Test Plan
- [x] 5 new tests for refresh config parsing (defaults, custom, partial, invalid, provider override)
- [x] Updated `EXPECTED_KEYS` and added `test_refresh_section_in_output` for `--config-help`
- [x] All 229 tests pass
- [x] Linter and formatter clean

*Co-authored by Claude*

🤖 Generated with [Claude Code](https://claude.com/claude-code)