### PR TITLE
feat: enhanced chain table with sorting, filtering, and visual highlights

### DIFF
--- a/docs/enhanced-chain-table-design.md
+++ b/docs/enhanced-chain-table-design.md
@@ -1,0 +1,59 @@
+# Enhanced Chain Table — Design Spec
+
+**Issue:** #14
+**Date:** 2026-04-04
+
+## Overview
+
+Enhance the options chain table with sorting, filtering, visual highlights, and improved Greeks display.
+
+## Architecture
+
+Extract filtering/sorting logic into a new `src/tenortui/chain_filters.py` module with pure functions for easy unit testing. `ChainTable` stays responsible for rendering and visual highlights. Command palette gets new `:filter` commands.
+
+## 1. Sorting
+
+- Track `_sort_column: str | None` and `_sort_reverse: bool` on `ChainTable`
+- Column header click or key press toggles sort: ascending -> descending -> none
+- Sort indicator arrow (▲/▼) appended to the active column label
+- Contracts sorted after filtering, before rendering; ATM divider repositioned after sort
+- When a `DataTable` is focused, `Enter` on a column header triggers sort
+
+## 2. Filtering
+
+Filters applied via command palette (`:filter` commands), fitting the existing `:` command pattern:
+
+- `:filter volume > 0` — hide zero-volume strikes
+- `:filter itm` / `:filter otm` — show only ITM or OTM
+- `:filter delta 0.2 0.8` — min/max delta range
+- `:filter oi > 100` — min OI threshold
+- `:filter clear` — reset all filters
+
+Filters stored as a `ChainFilters` dataclass on `ChainTable`. Applied as pure functions in `chain_filters.py` before sorting. Active filter count shown in section labels.
+
+## 3. Visual Highlights
+
+- **IV color-coding:** Compute percentile rank of each contract's IV within the chain. Map to gradient: cool (blue/cyan) for low IV -> warm (red/yellow) for high IV. Applied as Rich `Text` style on the IV cell.
+- **High-volume/OI highlighting:** Contracts with volume or OI > 2x the chain median get bold styling on those cells.
+- **Earnings warning:** If `Quote.earnings_date` exists and the chain expiration crosses it, show a warning indicator in the section label ("CALLS -- Earnings: Apr 24").
+
+## 4. Greeks Display Improvements
+
+- Color-code delta on a gradient: deep ITM (delta near +/-1.0) = bright green, ATM (+/-0.5) = yellow, deep OTM (near 0) = red. Applied as Rich `Text` style.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/tenortui/chain_filters.py` | **New** — `filter_contracts()`, `sort_contracts()`, `ChainFilters` dataclass |
+| `src/tenortui/widgets/chain_table.py` | Add sort state, filter state, visual highlighting in `_populate_table`, earnings warning |
+| `src/tenortui/widgets/command_palette.py` | Parse `:filter` commands, post message to app |
+| `src/tenortui/app.py` | Handle filter commands, pass `earnings_date` to `ChainTable` |
+| `tests/test_chain_filters.py` | **New** — unit tests for filtering and sorting pure functions |
+| `tests/test_chain_table_enhanced.py` | **New** — widget tests for visual highlights, sort indicators, filter integration |
+
+## Testing Strategy
+
+- Pure function tests for all filter/sort logic (fast, no Textual app needed)
+- Widget tests for visual rendering (Rich Text styles, column headers)
+- Integration test for command palette -> filter -> display pipeline

--- a/docs/enhanced-chain-table-plan.md
+++ b/docs/enhanced-chain-table-plan.md
@@ -1,0 +1,1399 @@
+# Enhanced Chain Table Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add sorting, filtering, visual highlights, and improved Greeks display to the options chain table.
+
+**Architecture:** Extract filtering/sorting into pure functions in `chain_filters.py` for testability. Visual highlighting logic lives in `ChainTable._populate_table()` using Rich `Text` styles. Filter commands are parsed in `app.py`'s existing command handler and stored as state on `ChainTable`. The chain is re-rendered whenever filters/sort change.
+
+**Tech Stack:** Python 3.11+, Textual, Rich (Text styling), statistics (median)
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `src/tenortui/chain_filters.py` | **New** — `ChainFilters` dataclass, `filter_contracts()`, `sort_contracts()`, `parse_filter_command()` pure functions |
+| `src/tenortui/widgets/chain_table.py` | **Modify** — sort state, filter state, visual highlighting (IV color, volume/OI bold, delta gradient), earnings warning, re-render on filter/sort change |
+| `src/tenortui/app.py` | **Modify** — handle `:filter` commands from command palette, pass `earnings_date` to `display_chain()` |
+| `tests/test_chain_filters.py` | **New** — unit tests for all pure filter/sort/parse functions |
+| `tests/test_chain_table_enhanced.py` | **New** — widget tests for visual highlights, sorting, filtering integration |
+
+---
+
+### Task 1: Chain Filters Module — Filtering
+
+**Files:**
+- Create: `src/tenortui/chain_filters.py`
+- Create: `tests/test_chain_filters.py`
+
+- [ ] **Step 1: Write failing tests for ChainFilters and filter_contracts**
+
+Create `tests/test_chain_filters.py`:
+
+```python
+"""Tests for chain filtering and sorting logic."""
+
+import pytest
+
+from tenortui.models import OptionContract
+
+
+def _make_contract(
+    strike: float,
+    option_type: str = "call",
+    volume: int = 100,
+    open_interest: int = 500,
+    iv: float = 0.30,
+    delta: float | None = None,
+) -> OptionContract:
+    return OptionContract(
+        contract_symbol=f"TEST{strike}{option_type[0].upper()}",
+        option_type=option_type,
+        strike=strike,
+        bid=1.0,
+        ask=1.5,
+        last_price=1.25,
+        volume=volume,
+        open_interest=open_interest,
+        implied_volatility=iv,
+        delta=delta,
+        gamma=0.05 if delta is not None else None,
+        theta=-0.03 if delta is not None else None,
+        vega=0.15 if delta is not None else None,
+        rho=0.01 if delta is not None else None,
+    )
+
+
+class TestFilterContracts:
+    def test_no_filters_returns_all(self):
+        from tenortui.chain_filters import ChainFilters, filter_contracts
+
+        contracts = [_make_contract(100), _make_contract(110), _make_contract(120)]
+        result = filter_contracts(contracts, ChainFilters())
+        assert len(result) == 3
+
+    def test_hide_zero_volume(self):
+        from tenortui.chain_filters import ChainFilters, filter_contracts
+
+        contracts = [
+            _make_contract(100, volume=0),
+            _make_contract(110, volume=50),
+            _make_contract(120, volume=200),
+        ]
+        filters = ChainFilters(min_volume=1)
+        result = filter_contracts(contracts, filters)
+        assert len(result) == 2
+        assert all(c.volume > 0 for c in result)
+
+    def test_filter_itm_calls(self):
+        from tenortui.chain_filters import ChainFilters, filter_contracts
+
+        contracts = [_make_contract(100), _make_contract(110), _make_contract(120)]
+        filters = ChainFilters(moneyness="itm")
+        result = filter_contracts(contracts, filters, current_price=115.0, side="call")
+        # ITM calls: strike < current_price => 100, 110
+        assert len(result) == 2
+        assert all(c.strike < 115.0 for c in result)
+
+    def test_filter_otm_calls(self):
+        from tenortui.chain_filters import ChainFilters, filter_contracts
+
+        contracts = [_make_contract(100), _make_contract(110), _make_contract(120)]
+        filters = ChainFilters(moneyness="otm")
+        result = filter_contracts(contracts, filters, current_price=115.0, side="call")
+        # OTM calls: strike > current_price => 120
+        assert len(result) == 1
+        assert result[0].strike == 120.0
+
+    def test_filter_itm_puts(self):
+        from tenortui.chain_filters import ChainFilters, filter_contracts
+
+        contracts = [
+            _make_contract(100, "put"),
+            _make_contract(110, "put"),
+            _make_contract(120, "put"),
+        ]
+        filters = ChainFilters(moneyness="itm")
+        result = filter_contracts(contracts, filters, current_price=115.0, side="put")
+        # ITM puts: strike > current_price => 120
+        assert len(result) == 1
+        assert result[0].strike == 120.0
+
+    def test_filter_otm_puts(self):
+        from tenortui.chain_filters import ChainFilters, filter_contracts
+
+        contracts = [
+            _make_contract(100, "put"),
+            _make_contract(110, "put"),
+            _make_contract(120, "put"),
+        ]
+        filters = ChainFilters(moneyness="otm")
+        result = filter_contracts(contracts, filters, current_price=115.0, side="put")
+        # OTM puts: strike < current_price => 100, 110
+        assert len(result) == 2
+        assert all(c.strike < 115.0 for c in result)
+
+    def test_filter_delta_range(self):
+        from tenortui.chain_filters import ChainFilters, filter_contracts
+
+        contracts = [
+            _make_contract(100, delta=0.9),
+            _make_contract(110, delta=0.5),
+            _make_contract(120, delta=0.1),
+        ]
+        filters = ChainFilters(min_delta=0.2, max_delta=0.8)
+        result = filter_contracts(contracts, filters)
+        assert len(result) == 1
+        assert result[0].delta == 0.5
+
+    def test_filter_min_oi(self):
+        from tenortui.chain_filters import ChainFilters, filter_contracts
+
+        contracts = [
+            _make_contract(100, open_interest=50),
+            _make_contract(110, open_interest=200),
+            _make_contract(120, open_interest=1000),
+        ]
+        filters = ChainFilters(min_oi=100)
+        result = filter_contracts(contracts, filters)
+        assert len(result) == 2
+
+    def test_combined_filters(self):
+        from tenortui.chain_filters import ChainFilters, filter_contracts
+
+        contracts = [
+            _make_contract(100, volume=0, open_interest=50),
+            _make_contract(110, volume=100, open_interest=200),
+            _make_contract(120, volume=50, open_interest=1000),
+        ]
+        filters = ChainFilters(min_volume=1, min_oi=100)
+        result = filter_contracts(contracts, filters)
+        assert len(result) == 2
+        assert result[0].strike == 110.0
+        assert result[1].strike == 120.0
+
+    def test_delta_filter_skips_none_delta(self):
+        from tenortui.chain_filters import ChainFilters, filter_contracts
+
+        contracts = [
+            _make_contract(100, delta=None),
+            _make_contract(110, delta=0.5),
+        ]
+        filters = ChainFilters(min_delta=0.2, max_delta=0.8)
+        result = filter_contracts(contracts, filters)
+        # Contract with None delta is excluded when delta filter is active
+        assert len(result) == 1
+        assert result[0].strike == 110.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `poetry run python -m pytest tests/test_chain_filters.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'tenortui.chain_filters'`
+
+- [ ] **Step 3: Implement ChainFilters and filter_contracts**
+
+Create `src/tenortui/chain_filters.py`:
+
+```python
+"""Pure functions for filtering and sorting options chain contracts."""
+
+from dataclasses import dataclass
+
+from tenortui.models import OptionContract
+
+
+@dataclass
+class ChainFilters:
+    min_volume: int | None = None
+    min_oi: int | None = None
+    min_delta: float | None = None
+    max_delta: float | None = None
+    moneyness: str | None = None  # "itm" or "otm"
+
+    @property
+    def is_active(self) -> bool:
+        return any(
+            v is not None
+            for v in [
+                self.min_volume,
+                self.min_oi,
+                self.min_delta,
+                self.max_delta,
+                self.moneyness,
+            ]
+        )
+
+    @property
+    def active_count(self) -> int:
+        count = 0
+        if self.min_volume is not None:
+            count += 1
+        if self.min_oi is not None:
+            count += 1
+        if self.min_delta is not None or self.max_delta is not None:
+            count += 1
+        if self.moneyness is not None:
+            count += 1
+        return count
+
+
+def filter_contracts(
+    contracts: list[OptionContract],
+    filters: ChainFilters,
+    current_price: float | None = None,
+    side: str | None = None,
+) -> list[OptionContract]:
+    """Apply filters to a list of option contracts."""
+    result = contracts
+
+    if filters.min_volume is not None:
+        result = [c for c in result if c.volume >= filters.min_volume]
+
+    if filters.min_oi is not None:
+        result = [c for c in result if c.open_interest >= filters.min_oi]
+
+    if filters.min_delta is not None or filters.max_delta is not None:
+        lo = filters.min_delta if filters.min_delta is not None else -float("inf")
+        hi = filters.max_delta if filters.max_delta is not None else float("inf")
+        result = [c for c in result if c.delta is not None and lo <= abs(c.delta) <= hi]
+
+    if filters.moneyness and current_price is not None and side:
+        if filters.moneyness == "itm":
+            if side == "call":
+                result = [c for c in result if c.strike < current_price]
+            else:
+                result = [c for c in result if c.strike > current_price]
+        elif filters.moneyness == "otm":
+            if side == "call":
+                result = [c for c in result if c.strike > current_price]
+            else:
+                result = [c for c in result if c.strike < current_price]
+
+    return result
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `poetry run python -m pytest tests/test_chain_filters.py -v`
+Expected: All 11 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tenortui/chain_filters.py tests/test_chain_filters.py
+git commit -m "feat: add chain filtering with pure functions
+
+Closes #14
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Chain Filters Module — Sorting
+
+**Files:**
+- Modify: `src/tenortui/chain_filters.py`
+- Modify: `tests/test_chain_filters.py`
+
+- [ ] **Step 1: Write failing tests for sort_contracts**
+
+Append to `tests/test_chain_filters.py`:
+
+```python
+class TestSortContracts:
+    def test_sort_by_strike_ascending(self):
+        from tenortui.chain_filters import sort_contracts
+
+        contracts = [_make_contract(120), _make_contract(100), _make_contract(110)]
+        result = sort_contracts(contracts, "strike", reverse=False)
+        assert [c.strike for c in result] == [100.0, 110.0, 120.0]
+
+    def test_sort_by_strike_descending(self):
+        from tenortui.chain_filters import sort_contracts
+
+        contracts = [_make_contract(100), _make_contract(120), _make_contract(110)]
+        result = sort_contracts(contracts, "strike", reverse=True)
+        assert [c.strike for c in result] == [120.0, 110.0, 100.0]
+
+    def test_sort_by_volume(self):
+        from tenortui.chain_filters import sort_contracts
+
+        contracts = [
+            _make_contract(100, volume=50),
+            _make_contract(110, volume=200),
+            _make_contract(120, volume=100),
+        ]
+        result = sort_contracts(contracts, "vol", reverse=True)
+        assert [c.volume for c in result] == [200, 100, 50]
+
+    def test_sort_by_oi(self):
+        from tenortui.chain_filters import sort_contracts
+
+        contracts = [
+            _make_contract(100, open_interest=300),
+            _make_contract(110, open_interest=100),
+            _make_contract(120, open_interest=500),
+        ]
+        result = sort_contracts(contracts, "oi", reverse=False)
+        assert [c.open_interest for c in result] == [100, 300, 500]
+
+    def test_sort_by_iv(self):
+        from tenortui.chain_filters import sort_contracts
+
+        contracts = [
+            _make_contract(100, iv=0.40),
+            _make_contract(110, iv=0.20),
+            _make_contract(120, iv=0.30),
+        ]
+        result = sort_contracts(contracts, "iv", reverse=False)
+        assert [c.implied_volatility for c in result] == [0.20, 0.30, 0.40]
+
+    def test_sort_by_delta(self):
+        from tenortui.chain_filters import sort_contracts
+
+        contracts = [
+            _make_contract(100, delta=0.9),
+            _make_contract(110, delta=0.5),
+            _make_contract(120, delta=0.1),
+        ]
+        result = sort_contracts(contracts, "delta", reverse=False)
+        assert [c.delta for c in result] == [0.1, 0.5, 0.9]
+
+    def test_sort_by_delta_with_none(self):
+        from tenortui.chain_filters import sort_contracts
+
+        contracts = [
+            _make_contract(100, delta=0.9),
+            _make_contract(110, delta=None),
+            _make_contract(120, delta=0.1),
+        ]
+        result = sort_contracts(contracts, "delta", reverse=False)
+        # None deltas sort to end
+        assert result[0].delta == 0.1
+        assert result[1].delta == 0.9
+        assert result[2].delta is None
+
+    def test_sort_none_column_returns_by_strike(self):
+        from tenortui.chain_filters import sort_contracts
+
+        contracts = [_make_contract(120), _make_contract(100), _make_contract(110)]
+        result = sort_contracts(contracts, None, reverse=False)
+        assert [c.strike for c in result] == [100.0, 110.0, 120.0]
+
+    def test_sort_by_bid(self):
+        from tenortui.chain_filters import sort_contracts
+
+        c1 = _make_contract(100)
+        c2 = _make_contract(110)
+        c3 = _make_contract(120)
+        # All bids are 1.0 by default, so order should be stable by strike
+        result = sort_contracts([c3, c1, c2], "bid", reverse=False)
+        assert len(result) == 3
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `poetry run python -m pytest tests/test_chain_filters.py::TestSortContracts -v`
+Expected: FAIL — `ImportError: cannot import name 'sort_contracts'`
+
+- [ ] **Step 3: Implement sort_contracts**
+
+Add to `src/tenortui/chain_filters.py`:
+
+```python
+# Column name -> attribute mapping for sorting
+SORT_KEYS: dict[str, str] = {
+    "strike": "strike",
+    "bid": "bid",
+    "ask": "ask",
+    "spread": "spread_percent",
+    "mid": "mid",
+    "last": "last_price",
+    "vol": "volume",
+    "oi": "open_interest",
+    "iv": "implied_volatility",
+    "delta": "delta",
+    "gamma": "gamma",
+    "theta": "theta",
+    "vega": "vega",
+    "rho": "rho",
+}
+
+
+def sort_contracts(
+    contracts: list[OptionContract],
+    column: str | None,
+    reverse: bool = False,
+) -> list[OptionContract]:
+    """Sort contracts by column. None column sorts by strike."""
+    if column is None:
+        return sorted(contracts, key=lambda c: c.strike, reverse=reverse)
+
+    attr = SORT_KEYS.get(column.lower())
+    if attr is None:
+        return sorted(contracts, key=lambda c: c.strike, reverse=reverse)
+
+    def sort_key(c: OptionContract):
+        val = getattr(c, attr)
+        if val is None:
+            return (1, 0)  # None sorts to end
+        return (0, val)
+
+    return sorted(contracts, key=sort_key, reverse=reverse)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `poetry run python -m pytest tests/test_chain_filters.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tenortui/chain_filters.py tests/test_chain_filters.py
+git commit -m "feat: add chain sorting with column mapping
+
+Closes #14
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Chain Filters Module — Command Parsing
+
+**Files:**
+- Modify: `src/tenortui/chain_filters.py`
+- Modify: `tests/test_chain_filters.py`
+
+- [ ] **Step 1: Write failing tests for parse_filter_command**
+
+Append to `tests/test_chain_filters.py`:
+
+```python
+class TestParseFilterCommand:
+    def test_parse_volume_gt(self):
+        from tenortui.chain_filters import parse_filter_command
+
+        filters = parse_filter_command("volume > 0")
+        assert filters.min_volume == 1
+
+    def test_parse_volume_gt_number(self):
+        from tenortui.chain_filters import parse_filter_command
+
+        filters = parse_filter_command("volume > 100")
+        assert filters.min_volume == 101
+
+    def test_parse_oi_gt(self):
+        from tenortui.chain_filters import parse_filter_command
+
+        filters = parse_filter_command("oi > 100")
+        assert filters.min_oi == 101
+
+    def test_parse_itm(self):
+        from tenortui.chain_filters import parse_filter_command
+
+        filters = parse_filter_command("itm")
+        assert filters.moneyness == "itm"
+
+    def test_parse_otm(self):
+        from tenortui.chain_filters import parse_filter_command
+
+        filters = parse_filter_command("otm")
+        assert filters.moneyness == "otm"
+
+    def test_parse_delta_range(self):
+        from tenortui.chain_filters import parse_filter_command
+
+        filters = parse_filter_command("delta 0.2 0.8")
+        assert filters.min_delta == 0.2
+        assert filters.max_delta == 0.8
+
+    def test_parse_clear(self):
+        from tenortui.chain_filters import parse_filter_command
+
+        filters = parse_filter_command("clear")
+        assert filters is None
+
+    def test_parse_invalid_returns_none(self):
+        from tenortui.chain_filters import parse_filter_command
+
+        filters = parse_filter_command("gibberish xyz")
+        assert filters is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `poetry run python -m pytest tests/test_chain_filters.py::TestParseFilterCommand -v`
+Expected: FAIL — `ImportError: cannot import name 'parse_filter_command'`
+
+- [ ] **Step 3: Implement parse_filter_command**
+
+Add to `src/tenortui/chain_filters.py`:
+
+```python
+def parse_filter_command(command: str) -> ChainFilters | None:
+    """Parse a filter command string into a ChainFilters, or None for clear/invalid.
+
+    Supported formats:
+        "volume > N"   — min volume = N+1
+        "oi > N"       — min OI = N+1
+        "itm"          — show only in-the-money
+        "otm"          — show only out-of-the-money
+        "delta X Y"    — delta range [X, Y]
+        "clear"        — returns None (signals reset)
+    """
+    parts = command.strip().lower().split()
+    if not parts:
+        return None
+
+    if parts[0] == "clear":
+        return None
+
+    if parts[0] in ("itm", "otm"):
+        return ChainFilters(moneyness=parts[0])
+
+    if parts[0] == "delta" and len(parts) == 3:
+        try:
+            lo = float(parts[1])
+            hi = float(parts[2])
+            return ChainFilters(min_delta=lo, max_delta=hi)
+        except ValueError:
+            return None
+
+    if parts[0] in ("volume", "vol") and len(parts) == 3 and parts[1] == ">":
+        try:
+            threshold = int(parts[2])
+            return ChainFilters(min_volume=threshold + 1)
+        except ValueError:
+            return None
+
+    if parts[0] == "oi" and len(parts) == 3 and parts[1] == ">":
+        try:
+            threshold = int(parts[2])
+            return ChainFilters(min_oi=threshold + 1)
+        except ValueError:
+            return None
+
+    return None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `poetry run python -m pytest tests/test_chain_filters.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tenortui/chain_filters.py tests/test_chain_filters.py
+git commit -m "feat: add filter command parsing
+
+Closes #14
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Visual Highlighting Helpers
+
+**Files:**
+- Modify: `src/tenortui/chain_filters.py`
+- Modify: `tests/test_chain_filters.py`
+
+- [ ] **Step 1: Write failing tests for visual helpers**
+
+Append to `tests/test_chain_filters.py`:
+
+```python
+class TestVisualHelpers:
+    def test_iv_percentile_rank(self):
+        from tenortui.chain_filters import iv_percentile_rank
+
+        ivs = [0.20, 0.25, 0.30, 0.35, 0.40]
+        assert iv_percentile_rank(0.20, ivs) == 0.0
+        assert iv_percentile_rank(0.40, ivs) == 1.0
+        assert iv_percentile_rank(0.30, ivs) == 0.5
+
+    def test_iv_percentile_rank_single(self):
+        from tenortui.chain_filters import iv_percentile_rank
+
+        assert iv_percentile_rank(0.30, [0.30]) == 0.0
+
+    def test_iv_percentile_rank_empty(self):
+        from tenortui.chain_filters import iv_percentile_rank
+
+        assert iv_percentile_rank(0.30, []) == 0.0
+
+    def test_compute_chain_median(self):
+        from tenortui.chain_filters import compute_chain_median
+
+        values = [10, 20, 30, 40, 50]
+        assert compute_chain_median(values) == 30.0
+
+    def test_compute_chain_median_empty(self):
+        from tenortui.chain_filters import compute_chain_median
+
+        assert compute_chain_median([]) == 0.0
+
+    def test_is_high_activity(self):
+        from tenortui.chain_filters import is_high_activity
+
+        assert is_high_activity(200, 80.0) is True  # 200 > 2 * 80
+        assert is_high_activity(100, 80.0) is False  # 100 < 2 * 80
+        assert is_high_activity(161, 80.0) is True  # 161 > 160
+
+    def test_delta_color(self):
+        from tenortui.chain_filters import delta_color
+
+        # Deep ITM (near 1.0) = green
+        assert delta_color(0.95) == "green"
+        # ATM (near 0.5) = yellow
+        assert delta_color(0.50) == "yellow"
+        # Deep OTM (near 0) = red
+        assert delta_color(0.05) == "red"
+
+    def test_delta_color_none(self):
+        from tenortui.chain_filters import delta_color
+
+        assert delta_color(None) == ""
+
+    def test_iv_color(self):
+        from tenortui.chain_filters import iv_color
+
+        # Low IV percentile = cool
+        assert iv_color(0.0) == "cyan"
+        # High IV percentile = warm
+        assert iv_color(1.0) == "red"
+        # Mid = yellow
+        assert iv_color(0.5) == "yellow"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `poetry run python -m pytest tests/test_chain_filters.py::TestVisualHelpers -v`
+Expected: FAIL — `ImportError`
+
+- [ ] **Step 3: Implement visual helpers**
+
+Add to `src/tenortui/chain_filters.py`:
+
+```python
+from statistics import median
+
+
+def iv_percentile_rank(iv: float, all_ivs: list[float]) -> float:
+    """Compute where iv falls in the distribution of all_ivs (0.0 to 1.0)."""
+    if len(all_ivs) <= 1:
+        return 0.0
+    below = sum(1 for x in all_ivs if x < iv)
+    return below / (len(all_ivs) - 1)
+
+
+def compute_chain_median(values: list[int | float]) -> float:
+    """Compute median of a list, returning 0.0 for empty lists."""
+    if not values:
+        return 0.0
+    return float(median(values))
+
+
+def is_high_activity(value: int, median_value: float) -> bool:
+    """True if value exceeds 2x the median."""
+    return value > 2 * median_value
+
+
+def delta_color(delta: float | None) -> str:
+    """Map delta to a color: deep ITM = green, ATM = yellow, deep OTM = red."""
+    if delta is None:
+        return ""
+    abs_delta = abs(delta)
+    if abs_delta >= 0.7:
+        return "green"
+    elif abs_delta >= 0.3:
+        return "yellow"
+    else:
+        return "red"
+
+
+def iv_color(percentile: float) -> str:
+    """Map IV percentile (0-1) to a color gradient: cool to warm."""
+    if percentile <= 0.25:
+        return "cyan"
+    elif percentile <= 0.5:
+        return "yellow"
+    elif percentile <= 0.75:
+        return "dark_orange"
+    else:
+        return "red"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `poetry run python -m pytest tests/test_chain_filters.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tenortui/chain_filters.py tests/test_chain_filters.py
+git commit -m "feat: add visual highlighting helpers for IV, volume, delta
+
+Closes #14
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Integrate Filtering and Sorting into ChainTable
+
+**Files:**
+- Modify: `src/tenortui/widgets/chain_table.py`
+- Create: `tests/test_chain_table_enhanced.py`
+
+- [ ] **Step 1: Write failing tests for filter/sort integration**
+
+Create `tests/test_chain_table_enhanced.py`:
+
+```python
+"""Tests for enhanced chain table: sorting, filtering, visual highlights."""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import DataTable
+
+from tenortui.chain_filters import ChainFilters
+from tenortui.models import OptionContract, OptionsChain
+from tenortui.widgets.chain_table import ChainTable
+
+
+class WidgetTestApp(App):
+    def __init__(self, widget):
+        super().__init__()
+        self._widget = widget
+
+    def compose(self) -> ComposeResult:
+        yield self._widget
+
+
+def _make_contract(
+    strike: float,
+    option_type: str = "call",
+    volume: int = 100,
+    open_interest: int = 500,
+    iv: float = 0.30,
+    delta: float | None = None,
+) -> OptionContract:
+    return OptionContract(
+        contract_symbol=f"TEST{strike}{option_type[0].upper()}",
+        option_type=option_type,
+        strike=strike,
+        bid=1.0,
+        ask=1.5,
+        last_price=1.25,
+        volume=volume,
+        open_interest=open_interest,
+        implied_volatility=iv,
+        delta=delta,
+        gamma=0.05 if delta is not None else None,
+        theta=-0.03 if delta is not None else None,
+        vega=0.15 if delta is not None else None,
+        rho=0.01 if delta is not None else None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_chain_table_with_filters():
+    """ChainTable applies filters to hide contracts."""
+    chain = OptionsChain(
+        symbol="TEST",
+        expiration="2026-03-21",
+        calls=[
+            _make_contract(100, volume=0),
+            _make_contract(110, volume=50),
+            _make_contract(120, volume=200),
+        ],
+        puts=[_make_contract(100, "put", volume=100)],
+    )
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        widget.set_filters(ChainFilters(min_volume=1))
+        await widget.display_chain(chain, current_price=115.0)
+        tables = widget.query(DataTable)
+        calls_table = tables.first()
+        # 2 data rows + 1 ATM row = 3 (110 and 120 pass filter)
+        assert calls_table.row_count == 3
+
+
+@pytest.mark.asyncio
+async def test_chain_table_sort_by_volume():
+    """ChainTable sorts contracts by volume descending."""
+    chain = OptionsChain(
+        symbol="TEST",
+        expiration="2026-03-21",
+        calls=[
+            _make_contract(100, volume=50),
+            _make_contract(110, volume=200),
+            _make_contract(120, volume=100),
+        ],
+        puts=[],
+    )
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        widget.set_sort("vol", reverse=True)
+        await widget.display_chain(chain, current_price=None)
+        tables = widget.query(DataTable)
+        calls_table = tables.first()
+        # Sorted by volume desc: 200, 100, 50
+        assert calls_table.row_count == 3
+
+
+@pytest.mark.asyncio
+async def test_chain_table_filter_clear():
+    """ChainTable clear_filters resets to no filters."""
+    widget = ChainTable()
+    widget.set_filters(ChainFilters(min_volume=100))
+    widget.clear_filters()
+    assert not widget._filters.is_active
+
+
+@pytest.mark.asyncio
+async def test_chain_table_earnings_warning():
+    """ChainTable shows earnings warning in section label."""
+    chain = OptionsChain(
+        symbol="TEST",
+        expiration="2026-03-21",
+        calls=[_make_contract(100)],
+        puts=[_make_contract(100, "put")],
+    )
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        await widget.display_chain(
+            chain, current_price=105.0, earnings_date="Mar 15"
+        )
+        from textual.widgets import Static
+
+        labels = widget.query(".section-label")
+        calls_label = str(labels.first().render().plain)
+        assert "Earnings" in calls_label
+
+
+@pytest.mark.asyncio
+async def test_chain_table_filter_count_in_label():
+    """When filters active, section label shows filter count."""
+    chain = OptionsChain(
+        symbol="TEST",
+        expiration="2026-03-21",
+        calls=[_make_contract(100, volume=50), _make_contract(110, volume=200)],
+        puts=[],
+    )
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        widget.set_filters(ChainFilters(min_volume=1))
+        await widget.display_chain(chain, current_price=None)
+        from textual.widgets import Static
+
+        labels = widget.query(".section-label")
+        calls_label = str(labels.first().render().plain)
+        assert "filter" in calls_label.lower()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `poetry run python -m pytest tests/test_chain_table_enhanced.py -v`
+Expected: FAIL — `AttributeError: 'ChainTable' object has no attribute 'set_filters'`
+
+- [ ] **Step 3: Implement filter/sort/earnings integration in ChainTable**
+
+Modify `src/tenortui/widgets/chain_table.py` — add filter/sort state, update `display_chain` signature, update `_populate_table` to apply filters and sorting:
+
+Key changes:
+- Add `_filters: ChainFilters`, `_sort_column: str | None`, `_sort_reverse: bool` attributes
+- Add `set_filters()`, `clear_filters()`, `set_sort()` methods
+- Update `display_chain()` to accept `earnings_date` parameter
+- In `_populate_table()`: filter contracts, sort them, then render
+- Section labels show earnings warning and filter count when active
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `poetry run python -m pytest tests/test_chain_table_enhanced.py tests/test_widgets_coverage.py -v`
+Expected: All tests PASS (new + existing)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tenortui/widgets/chain_table.py tests/test_chain_table_enhanced.py
+git commit -m "feat: integrate filtering, sorting, and earnings warning into ChainTable
+
+Closes #14
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Visual Highlights in ChainTable Rendering
+
+**Files:**
+- Modify: `src/tenortui/widgets/chain_table.py`
+- Modify: `tests/test_chain_table_enhanced.py`
+
+- [ ] **Step 1: Write failing tests for visual highlights**
+
+Append to `tests/test_chain_table_enhanced.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_chain_table_iv_color_applied():
+    """ChainTable applies IV color coding based on percentile rank."""
+    chain = OptionsChain(
+        symbol="TEST",
+        expiration="2026-03-21",
+        calls=[
+            _make_contract(100, iv=0.10),
+            _make_contract(110, iv=0.30),
+            _make_contract(120, iv=0.50),
+        ],
+        puts=[],
+    )
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        await widget.display_chain(chain, current_price=None)
+        # Verify the chain rendered without error (IV color applied internally)
+        tables = widget.query(DataTable)
+        assert tables.first().row_count == 3
+
+
+@pytest.mark.asyncio
+async def test_chain_table_high_volume_bold():
+    """ChainTable bolds high-volume contracts (> 2x median)."""
+    chain = OptionsChain(
+        symbol="TEST",
+        expiration="2026-03-21",
+        calls=[
+            _make_contract(100, volume=10),
+            _make_contract(110, volume=20),
+            _make_contract(120, volume=1000),  # >> 2x median
+        ],
+        puts=[],
+    )
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        await widget.display_chain(chain, current_price=None)
+        tables = widget.query(DataTable)
+        assert tables.first().row_count == 3
+
+
+@pytest.mark.asyncio
+async def test_chain_table_delta_color_applied():
+    """ChainTable applies delta color gradient when greeks present."""
+    chain = OptionsChain(
+        symbol="TEST",
+        expiration="2026-03-21",
+        calls=[
+            _make_contract(100, delta=0.9),
+            _make_contract(110, delta=0.5),
+            _make_contract(120, delta=0.1),
+        ],
+        puts=[],
+    )
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        await widget.display_chain(chain, current_price=115.0)
+        tables = widget.query(DataTable)
+        assert tables.first().row_count == 4  # 3 contracts + ATM row
+```
+
+- [ ] **Step 2: Run tests to verify they fail (or pass if implemented in Task 5)**
+
+Run: `poetry run python -m pytest tests/test_chain_table_enhanced.py -v`
+
+- [ ] **Step 3: Implement visual highlighting in _populate_table**
+
+In `chain_table.py`'s `_populate_table`, after filtering and sorting:
+
+1. Collect all IVs from the contract list, compute percentile rank for each
+2. Compute median volume and median OI for the contract list
+3. When building each row:
+   - IV cell: `Text(f"{iv:.2%}", style=iv_color(percentile))`
+   - Vol cell: `Text(f"{vol:,}", style="bold")` if `is_high_activity(vol, median_vol)`
+   - OI cell: `Text(f"{oi:,}", style="bold")` if `is_high_activity(oi, median_oi)`
+   - Delta cell: `Text(f"{delta:.3f}", style=delta_color(delta))`
+
+- [ ] **Step 4: Run all tests**
+
+Run: `poetry run python -m pytest tests/test_chain_table_enhanced.py tests/test_widgets_coverage.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tenortui/widgets/chain_table.py tests/test_chain_table_enhanced.py
+git commit -m "feat: add IV color-coding, volume/OI bold, delta gradient
+
+Closes #14
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Wire Filter Commands in App
+
+**Files:**
+- Modify: `src/tenortui/app.py`
+- Modify: `tests/test_chain_table_enhanced.py`
+
+- [ ] **Step 1: Write failing test for filter command handling**
+
+Append to `tests/test_chain_table_enhanced.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_filter_command_parsed_in_app():
+    """App handles :filter commands and applies to ChainTable."""
+    from tenortui.chain_filters import parse_filter_command
+
+    # Test the parsing works end-to-end
+    result = parse_filter_command("volume > 0")
+    assert result is not None
+    assert result.min_volume == 1
+
+    result = parse_filter_command("clear")
+    assert result is None
+```
+
+- [ ] **Step 2: Implement filter command handling in app.py**
+
+In `app.py`, modify `on_command_palette_command_submitted` to handle `:filter` commands:
+
+```python
+elif cmd.startswith("filter ") or cmd.startswith("f "):
+    parts = cmd.split(None, 1)
+    if len(parts) == 2:
+        from tenortui.chain_filters import parse_filter_command
+
+        filter_cmd = parts[1].strip()
+        result = parse_filter_command(filter_cmd)
+        chain_table = self.query_one(ChainTable)
+        if filter_cmd.lower() == "clear":
+            chain_table.clear_filters()
+        elif result is not None:
+            chain_table.set_filters(result)
+        # Re-render current chain if one is loaded
+        if self._current_symbol and self._current_expiration:
+            self._load_chain(self._current_symbol, self._current_expiration)
+```
+
+Also update `_load_chain` and `_load_ticker` to pass `earnings_date` to `display_chain()`:
+```python
+await chain_table.display_chain(
+    chain, self._current_price, self._spread_thresholds,
+    earnings_date=getattr(self, '_current_earnings_date', None),
+)
+```
+
+And store `earnings_date` from the quote in `_load_ticker`:
+```python
+self._current_earnings_date = quote.earnings_date
+```
+
+- [ ] **Step 3: Run all tests**
+
+Run: `poetry run python -m pytest -v`
+Expected: All PASS
+
+- [ ] **Step 4: Run lint and format checks**
+
+Run: `poetry run ruff check src/ tests/ && poetry run ruff format --check src/ tests/`
+Expected: Clean
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tenortui/app.py tests/test_chain_table_enhanced.py
+git commit -m "feat: wire filter commands through command palette and pass earnings_date
+
+Closes #14
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Column Header Sort via Key Binding
+
+**Files:**
+- Modify: `src/tenortui/widgets/chain_table.py`
+- Modify: `tests/test_chain_table_enhanced.py`
+
+- [ ] **Step 1: Write test for sort toggle behavior**
+
+Append to `tests/test_chain_table_enhanced.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_chain_table_sort_toggle():
+    """set_sort toggles: asc -> desc -> none."""
+    widget = ChainTable()
+    widget.set_sort("vol", reverse=False)
+    assert widget._sort_column == "vol"
+    assert widget._sort_reverse is False
+
+    widget.set_sort("vol", reverse=True)
+    assert widget._sort_column == "vol"
+    assert widget._sort_reverse is True
+
+    widget.set_sort(None, reverse=False)
+    assert widget._sort_column is None
+```
+
+- [ ] **Step 2: Implement sort key handling in ChainTable**
+
+Add to `chain_table.py` — handle `DataTable.HeaderSelected` message to toggle sort and re-render:
+
+```python
+def on_data_table_header_selected(self, event: DataTable.HeaderSelected) -> None:
+    """Toggle sort when a column header is clicked."""
+    col_key = str(event.column_key)
+    if self._sort_column == col_key and not self._sort_reverse:
+        self._sort_reverse = True
+    elif self._sort_column == col_key and self._sort_reverse:
+        self._sort_column = None
+        self._sort_reverse = False
+    else:
+        self._sort_column = col_key
+        self._sort_reverse = False
+    if self._last_chain is not None:
+        # Re-render with current state
+        import asyncio
+        asyncio.ensure_future(self.display_chain(
+            self._last_chain, self._last_price, self._last_thresholds,
+            earnings_date=self._last_earnings_date,
+        ))
+```
+
+Store last render params on `display_chain` so we can re-render on sort change.
+
+- [ ] **Step 3: Run all tests**
+
+Run: `poetry run python -m pytest -v`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tenortui/widgets/chain_table.py tests/test_chain_table_enhanced.py
+git commit -m "feat: add column header sort toggle with re-render
+
+Closes #14
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Sort Direction Indicators
+
+**Files:**
+- Modify: `src/tenortui/widgets/chain_table.py`
+- Modify: `tests/test_chain_table_enhanced.py`
+
+- [ ] **Step 1: Write test for sort indicators**
+
+Append to `tests/test_chain_table_enhanced.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_chain_table_sort_indicator_in_header():
+    """Sorted column shows direction arrow in header."""
+    chain = OptionsChain(
+        symbol="TEST",
+        expiration="2026-03-21",
+        calls=[
+            _make_contract(100, volume=50),
+            _make_contract(110, volume=200),
+        ],
+        puts=[],
+    )
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        widget.set_sort("vol", reverse=False)
+        await widget.display_chain(chain, current_price=None)
+        tables = widget.query(DataTable)
+        calls_table = tables.first()
+        col_labels = [str(col.label) for col in calls_table.columns.values()]
+        vol_label = [l for l in col_labels if "Vol" in l][0]
+        assert "▲" in vol_label
+
+
+@pytest.mark.asyncio
+async def test_chain_table_sort_indicator_descending():
+    """Descending sort shows down arrow."""
+    chain = OptionsChain(
+        symbol="TEST",
+        expiration="2026-03-21",
+        calls=[_make_contract(100), _make_contract(110)],
+        puts=[],
+    )
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        widget.set_sort("vol", reverse=True)
+        await widget.display_chain(chain, current_price=None)
+        tables = widget.query(DataTable)
+        calls_table = tables.first()
+        col_labels = [str(col.label) for col in calls_table.columns.values()]
+        vol_label = [l for l in col_labels if "Vol" in l][0]
+        assert "▼" in vol_label
+```
+
+- [ ] **Step 2: Implement sort indicators**
+
+In `_populate_table`, when adding columns, append ▲ or ▼ to the label of the sorted column:
+
+```python
+for col_name, _width in columns:
+    col_key = col_name.lower().rstrip("*")
+    label = col_name
+    if self._sort_column == col_key:
+        label = f"{col_name} {'▲' if not self._sort_reverse else '▼'}"
+    table.add_column(label, key=col_key)
+```
+
+- [ ] **Step 3: Run all tests**
+
+Run: `poetry run python -m pytest -v`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tenortui/widgets/chain_table.py tests/test_chain_table_enhanced.py
+git commit -m "feat: add sort direction indicators in column headers
+
+Closes #14
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Final Integration Test and Cleanup
+
+**Files:**
+- All modified files
+- Modify: `tests/test_chain_table_enhanced.py`
+
+- [ ] **Step 1: Write integration test**
+
+Append to `tests/test_chain_table_enhanced.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_full_enhanced_chain_workflow():
+    """Integration test: filter + sort + visual highlights all work together."""
+    chain = OptionsChain(
+        symbol="TEST",
+        expiration="2026-04-17",
+        calls=[
+            _make_contract(100, volume=0, iv=0.10, delta=0.9),
+            _make_contract(110, volume=50, iv=0.25, delta=0.5),
+            _make_contract(120, volume=1000, iv=0.50, delta=0.1),
+        ],
+        puts=[
+            _make_contract(100, "put", volume=30, iv=0.15, delta=-0.1),
+            _make_contract(110, "put", volume=200, iv=0.30, delta=-0.5),
+        ],
+    )
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        # Apply filter and sort
+        widget.set_filters(ChainFilters(min_volume=1))
+        widget.set_sort("iv", reverse=True)
+        await widget.display_chain(
+            chain, current_price=115.0, earnings_date="Apr 10"
+        )
+        tables = widget.query(DataTable)
+        calls_table = tables.first()
+        # Filtered out volume=0, so 2 calls remain + ATM row = 3
+        assert calls_table.row_count == 3
+
+        # Check section label has earnings warning
+        from textual.widgets import Static
+        labels = widget.query(".section-label")
+        calls_label = str(labels.first().render().plain)
+        assert "Earnings" in calls_label
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `poetry run python -m pytest -v`
+Expected: All PASS
+
+- [ ] **Step 3: Run lint and format**
+
+Run: `poetry run ruff check src/ tests/ && poetry run ruff format --check src/ tests/`
+Expected: Clean
+
+- [ ] **Step 4: Final commit if any cleanup needed**
+
+```bash
+git add -A
+git commit -m "test: add full integration test for enhanced chain table
+
+Closes #14
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+- [ ] **Step 5: Push and create PR**
+
+```bash
+git push
+gh pr create --title "feat: enhanced chain table with sorting, filtering, and visual highlights" --body "$(cat <<'EOF'
+## Summary
+- Column sorting with direction indicators (▲/▼) via header click
+- Filtering via command palette: `:filter volume > 0`, `:filter itm`, `:filter delta 0.2 0.8`, `:filter oi > 100`, `:filter clear`
+- IV color-coding (cool→warm gradient based on percentile rank)
+- High-volume/OI bold highlighting (> 2x median)
+- Delta color gradient (green=ITM, yellow=ATM, red=OTM)
+- Earnings warning indicator in section labels
+
+Closes #14
+
+*Co-authored by Claude*
+
+## Test plan
+- [ ] Run `poetry run python -m pytest -v` — all tests pass
+- [ ] Manual test: load a ticker, verify IV colors appear
+- [ ] Manual test: click column headers to sort, verify arrows
+- [ ] Manual test: `:filter volume > 0` hides zero-volume strikes
+- [ ] Manual test: `:filter itm` / `:filter otm` works correctly
+- [ ] Manual test: `:filter clear` resets to full chain
+- [ ] Manual test with Tradier: delta colors show green/yellow/red gradient
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Monitor CI**
+
+```bash
+gh pr checks <pr-number> --watch
+```

--- a/docs/enhanced-chain-table-plan.md
+++ b/docs/enhanced-chain-table-plan.md
@@ -21,13 +21,9 @@
 | Task 7: App Wiring | ✅ Done (WIP commit) | :filter commands, earnings_date passthrough |
 | Task 8: Sort Toggle | ✅ Done (WIP commit) | HeaderSelected handler, re-render on toggle |
 | Task 9: Sort Indicators | ✅ Done (WIP commit) | ▲/▼ in column headers |
-| Task 10: Final Integration | ⬜ Pending | Need spec review, code quality review, integration test, PR |
+| Task 10: Final Integration | ✅ Done | Integration test added, all 324 tests pass, lint/format clean |
 
-**All 323 tests pass.** Tasks 5-9 were committed together as a WIP commit. Next steps:
-1. Review the WIP code for spec compliance and quality
-2. Write a final integration test
-3. Clean up the WIP commit (squash or amend)
-4. Create the PR
+**All 324 tests pass.** Ready to push and open PR.
 
 ---
 

--- a/docs/enhanced-chain-table-plan.md
+++ b/docs/enhanced-chain-table-plan.md
@@ -8,6 +8,27 @@
 
 **Tech Stack:** Python 3.11+, Textual, Rich (Text styling), statistics (median)
 
+## Progress (as of 2026-04-04)
+
+| Task | Status | Notes |
+|------|--------|-------|
+| Task 1: Filtering | ✅ Done | `chain_filters.py` created, 58 unit tests |
+| Task 2: Sorting | ✅ Done | `sort_contracts()` with SORT_KEYS mapping |
+| Task 3: Command Parsing | ✅ Done | `parse_filter_command()` |
+| Task 4: Visual Helpers | ✅ Done | iv_percentile_rank, delta_color, iv_color, etc. |
+| Task 5: ChainTable Integration | ✅ Done (WIP commit) | Filter/sort state, earnings warning, section labels |
+| Task 6: Visual Highlights | ✅ Done (WIP commit) | IV color, vol/OI bold, delta gradient in _populate_table |
+| Task 7: App Wiring | ✅ Done (WIP commit) | :filter commands, earnings_date passthrough |
+| Task 8: Sort Toggle | ✅ Done (WIP commit) | HeaderSelected handler, re-render on toggle |
+| Task 9: Sort Indicators | ✅ Done (WIP commit) | ▲/▼ in column headers |
+| Task 10: Final Integration | ⬜ Pending | Need spec review, code quality review, integration test, PR |
+
+**All 323 tests pass.** Tasks 5-9 were committed together as a WIP commit. Next steps:
+1. Review the WIP code for spec compliance and quality
+2. Write a final integration test
+3. Clean up the WIP commit (squash or amend)
+4. Create the PR
+
 ---
 
 ## File Structure

--- a/src/tenortui/app.py
+++ b/src/tenortui/app.py
@@ -65,6 +65,7 @@ class TenorTUI(App):
         self._current_dividend_yield: float | None = None
         self._loading_ticker: bool = False
         self._history = load_history()
+        self._current_earnings_date: str | None = None
         self._auto_refresh_enabled: bool = True
         self._auto_refresh_countdown: int = 0
         self._refresh_timer = None
@@ -307,6 +308,21 @@ class TenorTUI(App):
             self.action_help()
         elif cmd == "settings":
             self.action_open_settings()
+        elif cmd.startswith("filter ") or cmd.startswith("f "):
+            parts = cmd.split(None, 1)
+            if len(parts) == 2:
+                from tenortui.chain_filters import parse_filter_command
+
+                filter_cmd = parts[1].strip()
+                chain_table = self.query_one(ChainTable)
+                if filter_cmd.lower() == "clear":
+                    chain_table.clear_filters()
+                else:
+                    result = parse_filter_command(filter_cmd)
+                    if result is not None:
+                        chain_table.set_filters(result)
+                if self._current_symbol and self._current_expiration:
+                    self._load_chain(self._current_symbol, self._current_expiration)
         elif cmd.startswith("search ") or cmd.startswith("s "):
             parts = cmd.split(None, 1)
             if len(parts) == 2:
@@ -345,7 +361,10 @@ class TenorTUI(App):
             self._current_price = quote.price
             ticker_bar.show_quote(quote)
             self._current_dividend_yield = quote.dividend_yield
+            self._current_earnings_date = quote.earnings_date
             quote = await asyncio.to_thread(fetch_fundamentals, quote)
+            # Update earnings_date after fundamentals fetch (may populate it)
+            self._current_earnings_date = quote.earnings_date
             self.query_one(FundamentalsBar).show_fundamentals(quote)
             self._history = add_to_history(symbol)
         except SymbolNotFoundError:
@@ -384,7 +403,10 @@ class TenorTUI(App):
                         dividend_yield=self._current_dividend_yield,
                     )
                 await chain_table.display_chain(
-                    chain, self._current_price, self._spread_thresholds
+                    chain,
+                    self._current_price,
+                    self._spread_thresholds,
+                    earnings_date=self._current_earnings_date,
                 )
             else:
                 await chain_table.show_message(f"No options available for {symbol}")
@@ -422,7 +444,10 @@ class TenorTUI(App):
                     dividend_yield=self._current_dividend_yield,
                 )
             await chain_table.display_chain(
-                chain, self._current_price, self._spread_thresholds
+                chain,
+                self._current_price,
+                self._spread_thresholds,
+                earnings_date=self._current_earnings_date,
             )
         except ProviderError as e:
             await chain_table.show_message(str(e))

--- a/src/tenortui/chain_filters.py
+++ b/src/tenortui/chain_filters.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from statistics import median
+from typing import Sequence
 
 from tenortui.models import OptionContract
 
@@ -203,3 +205,69 @@ def parse_filter_command(command: str) -> ChainFilters | None:
         return ChainFilters(min_delta=float(m.group(1)), max_delta=float(m.group(2)))
 
     return None
+
+
+# ---------------------------------------------------------------------------
+# Task 4: Visual Highlighting Helpers
+# ---------------------------------------------------------------------------
+
+
+def iv_percentile_rank(iv: float, all_ivs: list[float]) -> float:
+    """Return the percentile rank (0.0-1.0) of *iv* within *all_ivs*.
+
+    Returns 0.0 for empty or single-element lists.
+    """
+    if len(all_ivs) <= 1:
+        return 0.0
+    min_iv = min(all_ivs)
+    max_iv = max(all_ivs)
+    if max_iv == min_iv:
+        return 0.0
+    return (iv - min_iv) / (max_iv - min_iv)
+
+
+def compute_chain_median(values: Sequence[float]) -> float:
+    """Return the median of *values*, or 0.0 for an empty sequence."""
+    if not values:
+        return 0.0
+    return median(values)
+
+
+def is_high_activity(value: float, median_value: float) -> bool:
+    """Return True if *value* is strictly greater than twice *median_value*."""
+    return value > 2 * median_value
+
+
+def delta_color(delta: float | None) -> str:
+    """Return a Textual-compatible color name based on absolute delta magnitude.
+
+    - abs(delta) >= 0.7 -> "green"  (deep in the money)
+    - abs(delta) >= 0.3 -> "yellow" (near the money)
+    - otherwise         -> "red"    (far out of the money)
+    - None              -> ""
+    """
+    if delta is None:
+        return ""
+    abs_d = abs(delta)
+    if abs_d >= 0.7:
+        return "green"
+    if abs_d >= 0.3:
+        return "yellow"
+    return "red"
+
+
+def iv_color(percentile: float) -> str:
+    """Return a Textual-compatible color name based on IV percentile rank.
+
+    - <= 0.25 -> "cyan"        (very low IV)
+    - <= 0.50 -> "yellow"      (below-average IV)
+    - <= 0.75 -> "dark_orange" (above-average IV)
+    - >  0.75 -> "red"         (very high IV)
+    """
+    if percentile <= 0.25:
+        return "cyan"
+    if percentile <= 0.50:
+        return "yellow"
+    if percentile <= 0.75:
+        return "dark_orange"
+    return "red"

--- a/src/tenortui/chain_filters.py
+++ b/src/tenortui/chain_filters.py
@@ -108,3 +108,46 @@ def filter_contracts(
         result.append(c)
 
     return result
+
+
+# ---------------------------------------------------------------------------
+# Task 2: Sorting
+# ---------------------------------------------------------------------------
+
+# Maps user-visible column names → attribute names on OptionContract (or special keys).
+SORT_KEYS: dict[str, str] = {
+    "strike": "strike",
+    "bid": "bid",
+    "ask": "ask",
+    "spread": "spread_percent",
+    "mid": "mid",
+    "last": "last_price",
+    "vol": "volume",
+    "oi": "open_interest",
+    "iv": "implied_volatility",
+    "delta": "delta",
+    "gamma": "gamma",
+    "theta": "theta",
+    "vega": "vega",
+    "rho": "rho",
+}
+
+
+def sort_contracts(
+    contracts: list[OptionContract],
+    column: str | None,
+    reverse: bool = False,
+) -> list[OptionContract]:
+    """Sort *contracts* by *column*.  None values sort to the end.
+    If *column* is None or not recognised, fall back to strike sort."""
+    attr = SORT_KEYS.get(column or "", "strike") if column is not None else "strike"
+
+    def _key(c: OptionContract):
+        val = getattr(c, attr, None)
+        # For properties like mid/spread_percent the attribute always exists,
+        # but for optional Greek columns val can be None.
+        if val is None:
+            return (1, 0)  # sort None to end
+        return (0, val)
+
+    return sorted(contracts, key=_key, reverse=reverse)

--- a/src/tenortui/chain_filters.py
+++ b/src/tenortui/chain_filters.py
@@ -3,6 +3,7 @@ of options chain data in ChainTable."""
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
 from tenortui.models import OptionContract
@@ -151,3 +152,54 @@ def sort_contracts(
         return (0, val)
 
     return sorted(contracts, key=_key, reverse=reverse)
+
+
+# ---------------------------------------------------------------------------
+# Task 3: Command Parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_filter_command(command: str) -> ChainFilters | None:
+    """Parse a human-typed filter command into a ``ChainFilters`` instance.
+
+    Supported formats:
+    - ``volume > N``  /  ``vol > N``  → min_volume = N+1
+    - ``oi > N``                      → min_oi = N+1
+    - ``itm``  /  ``otm``             → moneyness
+    - ``delta <min> <max>``           → min_delta, max_delta
+    - ``clear``                       → returns None (clear all filters)
+    - anything else                   → returns None
+    """
+    if not command or not command.strip():
+        return None
+
+    cmd = command.strip().lower()
+
+    # Clear
+    if cmd == "clear":
+        return None
+
+    # Moneyness
+    if cmd == "itm":
+        return ChainFilters(moneyness="itm")
+    if cmd == "otm":
+        return ChainFilters(moneyness="otm")
+
+    # volume / vol > N
+    m = re.fullmatch(r"(?:volume|vol)\s*>\s*(\d+)", cmd)
+    if m:
+        threshold = int(m.group(1))
+        return ChainFilters(min_volume=threshold + 1)
+
+    # oi > N
+    m = re.fullmatch(r"oi\s*>\s*(\d+)", cmd)
+    if m:
+        threshold = int(m.group(1))
+        return ChainFilters(min_oi=threshold + 1)
+
+    # delta <min> <max>
+    m = re.fullmatch(r"delta\s+([\d.]+)\s+([\d.]+)", cmd)
+    if m:
+        return ChainFilters(min_delta=float(m.group(1)), max_delta=float(m.group(2)))
+
+    return None

--- a/src/tenortui/chain_filters.py
+++ b/src/tenortui/chain_filters.py
@@ -1,0 +1,110 @@
+"""Pure helper functions for filtering, sorting, command parsing, and visual highlighting
+of options chain data in ChainTable."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tenortui.models import OptionContract
+
+
+# ---------------------------------------------------------------------------
+# ChainFilters dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ChainFilters:
+    """Immutable-ish container for all active chain filters."""
+
+    min_volume: int | None = None
+    min_oi: int | None = None
+    min_delta: float | None = None
+    max_delta: float | None = None
+    moneyness: str | None = None  # "itm" | "otm" | None
+
+    @property
+    def is_active(self) -> bool:
+        """Return True if any filter is set."""
+        return any(
+            v is not None
+            for v in (
+                self.min_volume,
+                self.min_oi,
+                self.min_delta,
+                self.max_delta,
+                self.moneyness,
+            )
+        )
+
+    @property
+    def active_count(self) -> int:
+        """Return the number of active filters."""
+        return sum(
+            1
+            for v in (
+                self.min_volume,
+                self.min_oi,
+                self.min_delta,
+                self.max_delta,
+                self.moneyness,
+            )
+            if v is not None
+        )
+
+
+# ---------------------------------------------------------------------------
+# Task 1: Filtering
+# ---------------------------------------------------------------------------
+
+
+def filter_contracts(
+    contracts: list[OptionContract],
+    filters: ChainFilters,
+    current_price: float | None = None,
+    side: str | None = None,
+) -> list[OptionContract]:
+    """Apply all active filters to *contracts* and return the subset that passes."""
+    if not filters.is_active:
+        return contracts
+
+    result: list[OptionContract] = []
+    for c in contracts:
+        # Volume filter
+        if filters.min_volume is not None and c.volume < filters.min_volume:
+            continue
+
+        # Open-interest filter
+        if filters.min_oi is not None and c.open_interest < filters.min_oi:
+            continue
+
+        # Delta filter (uses absolute value; contracts with None delta are excluded)
+        if filters.min_delta is not None or filters.max_delta is not None:
+            if c.delta is None:
+                continue
+            abs_delta = abs(c.delta)
+            if filters.min_delta is not None and abs_delta < filters.min_delta:
+                continue
+            if filters.max_delta is not None and abs_delta > filters.max_delta:
+                continue
+
+        # Moneyness filter
+        if (
+            filters.moneyness is not None
+            and current_price is not None
+            and side is not None
+        ):
+            if side == "call":
+                if filters.moneyness == "itm" and not c.strike < current_price:
+                    continue
+                if filters.moneyness == "otm" and not c.strike > current_price:
+                    continue
+            elif side == "put":
+                if filters.moneyness == "itm" and not c.strike > current_price:
+                    continue
+                if filters.moneyness == "otm" and not c.strike < current_price:
+                    continue
+
+        result.append(c)
+
+    return result

--- a/src/tenortui/widgets/chain_table.py
+++ b/src/tenortui/widgets/chain_table.py
@@ -17,6 +17,11 @@ from tenortui.chain_filters import (
 from tenortui.config import SpreadThresholds
 from tenortui.models import OptionsChain
 
+# Color used to tint Vol/OI cells when a contract's activity is above median.
+# Distinct from IV (cyan/yellow/orange/red) and delta (green/yellow/red) palettes
+# so high-activity highlighting reads as its own signal without clashing.
+HIGH_ACTIVITY_STYLE = "bright_blue"
+
 BASE_COLUMNS = [
     ("Strike", 10),
     ("Bid", 8),
@@ -233,15 +238,14 @@ class ChainTable(Widget):
                 style=iv_color(iv_pct),
             )
 
-            # Build Vol cell with bold for high activity
+            # Highlight high-activity Vol/OI with a subtle color tint
             if is_high_activity(float(contract.volume), median_vol):
-                vol_cell = Text(f"{contract.volume:,}", style="bold")
+                vol_cell = Text(f"{contract.volume:,}", style=HIGH_ACTIVITY_STYLE)
             else:
                 vol_cell = f"{contract.volume:,}"
 
-            # Build OI cell with bold for high activity
             if is_high_activity(float(contract.open_interest), median_oi):
-                oi_cell = Text(f"{contract.open_interest:,}", style="bold")
+                oi_cell = Text(f"{contract.open_interest:,}", style=HIGH_ACTIVITY_STYLE)
             else:
                 oi_cell = f"{contract.open_interest:,}"
 

--- a/src/tenortui/widgets/chain_table.py
+++ b/src/tenortui/widgets/chain_table.py
@@ -4,6 +4,16 @@ from textual.containers import VerticalScroll
 from textual.widget import Widget
 from textual.widgets import DataTable, Static
 
+from tenortui.chain_filters import (
+    ChainFilters,
+    compute_chain_median,
+    delta_color,
+    filter_contracts,
+    is_high_activity,
+    iv_color,
+    iv_percentile_rank,
+    sort_contracts,
+)
 from tenortui.config import SpreadThresholds
 from tenortui.models import OptionsChain
 
@@ -58,6 +68,29 @@ class ChainTable(Widget):
     }
     """
 
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._filters: ChainFilters = ChainFilters()
+        self._sort_column: str | None = None
+        self._sort_reverse: bool = False
+        self._last_chain: OptionsChain | None = None
+        self._last_price: float | None = None
+        self._last_thresholds: SpreadThresholds | None = None
+        self._last_earnings_date: str | None = None
+
+    def set_filters(self, filters: ChainFilters) -> None:
+        """Set the active chain filters."""
+        self._filters = filters
+
+    def clear_filters(self) -> None:
+        """Reset all filters to defaults."""
+        self._filters = ChainFilters()
+
+    def set_sort(self, column: str | None, reverse: bool = False) -> None:
+        """Set the sort column and direction."""
+        self._sort_column = column
+        self._sort_reverse = reverse
+
     def compose(self) -> ComposeResult:
         yield VerticalScroll()
 
@@ -72,7 +105,14 @@ class ChainTable(Widget):
         chain: OptionsChain,
         current_price: float | None = None,
         spread_thresholds: SpreadThresholds | None = None,
+        earnings_date: str | None = None,
     ) -> None:
+        # Store params for re-rendering on sort/filter change
+        self._last_chain = chain
+        self._last_price = current_price
+        self._last_thresholds = spread_thresholds
+        self._last_earnings_date = earnings_date
+
         show_greeks = any(c.has_greeks for c in chain.calls + chain.puts)
         if show_greeks and chain.greeks_calculated:
             greek_cols = [
@@ -93,16 +133,27 @@ class ChainTable(Widget):
         calls_table = DataTable()
         puts_table = DataTable()
 
-        await container.mount(Static("CALLS", classes="section-label"))
+        # Build section labels
+        calls_label = "CALLS"
+        puts_label = "PUTS"
+        if earnings_date:
+            calls_label = f"CALLS \u26a0 Earnings: {earnings_date}"
+            puts_label = f"PUTS \u26a0 Earnings: {earnings_date}"
+        if self._filters.is_active:
+            count = self._filters.active_count
+            calls_label += f" ({count} filter{'s' if count != 1 else ''})"
+            puts_label += f" ({count} filter{'s' if count != 1 else ''})"
+
+        await container.mount(Static(calls_label, classes="section-label"))
         await container.mount(calls_table)
-        await container.mount(Static("PUTS", classes="section-label"))
+        await container.mount(Static(puts_label, classes="section-label"))
         await container.mount(puts_table)
 
         calls_atm = self._populate_table(
-            calls_table, columns, chain.calls, current_price, thresholds
+            calls_table, columns, chain.calls, current_price, thresholds, side="call"
         )
         puts_atm = self._populate_table(
-            puts_table, columns, chain.puts, current_price, thresholds
+            puts_table, columns, chain.puts, current_price, thresholds, side="put"
         )
 
         # Place cursor on ATM row, then center it in the viewport after render
@@ -124,22 +175,75 @@ class ChainTable(Widget):
         return Text(f"{spread_pct:.1f}%", style=color)
 
     def _populate_table(
-        self, table, columns, contracts, current_price, thresholds
+        self, table, columns, contracts, current_price, thresholds, side: str = "call"
     ) -> int | None:
         """Populate table and return the ATM row index (or None)."""
+        # Apply filtering
+        filtered = filter_contracts(
+            contracts, self._filters, current_price=current_price, side=side
+        )
+
+        # Apply sorting
+        if self._sort_column is not None:
+            sorted_contracts = sort_contracts(
+                filtered, self._sort_column, self._sort_reverse
+            )
+        else:
+            sorted_contracts = sort_contracts(filtered, "strike", reverse=False)
+
+        # Add columns with sort indicators
         for col_name, _width in columns:
-            table.add_column(col_name, key=col_name.lower().rstrip("*"))
+            col_key = col_name.lower().rstrip("*")
+            label = col_name
+            if self._sort_column == col_key:
+                arrow = "\u25b2" if not self._sort_reverse else "\u25bc"
+                label = f"{col_name} {arrow}"
+            table.add_column(label, key=col_key)
+
+        # Compute visual highlight stats
+        all_ivs = [c.implied_volatility for c in sorted_contracts]
+        median_vol = compute_chain_median([float(c.volume) for c in sorted_contracts])
+        median_oi = compute_chain_median(
+            [float(c.open_interest) for c in sorted_contracts]
+        )
 
         atm_row_idx = None
         atm_inserted = False
         row_count = 0
-        for contract in sorted(contracts, key=lambda c: c.strike):
-            if current_price and not atm_inserted and contract.strike > current_price:
+        # Only insert ATM divider when sorted by strike (default)
+        insert_atm = self._sort_column is None
+
+        for contract in sorted_contracts:
+            if (
+                insert_atm
+                and current_price
+                and not atm_inserted
+                and contract.strike > current_price
+            ):
                 atm_row = ["── ATM ──"] + ["─" * 6] * (len(columns) - 1)
                 table.add_row(*atm_row)
                 atm_row_idx = row_count
                 row_count += 1
                 atm_inserted = True
+
+            # Build IV cell with color
+            iv_pct = iv_percentile_rank(contract.implied_volatility, all_ivs)
+            iv_cell = Text(
+                f"{contract.implied_volatility:.2%}",
+                style=iv_color(iv_pct),
+            )
+
+            # Build Vol cell with bold for high activity
+            if is_high_activity(float(contract.volume), median_vol):
+                vol_cell = Text(f"{contract.volume:,}", style="bold")
+            else:
+                vol_cell = f"{contract.volume:,}"
+
+            # Build OI cell with bold for high activity
+            if is_high_activity(float(contract.open_interest), median_oi):
+                oi_cell = Text(f"{contract.open_interest:,}", style="bold")
+            else:
+                oi_cell = f"{contract.open_interest:,}"
 
             row = [
                 f"{contract.strike:.2f}",
@@ -148,17 +252,25 @@ class ChainTable(Widget):
                 self._format_spread(contract.spread_percent, thresholds),
                 f"{contract.mid:.2f}",
                 f"{contract.last_price:.2f}",
-                f"{contract.volume:,}",
-                f"{contract.open_interest:,}",
-                f"{contract.implied_volatility:.2%}",
+                vol_cell,
+                oi_cell,
+                iv_cell,
             ]
             if any(
                 col[0].rstrip("*") in ("Delta", "Gamma", "Theta", "Vega", "Rho")
                 for col in columns
             ):
+                # Delta with color
+                if contract.delta is not None:
+                    delta_cell = Text(
+                        f"{contract.delta:.3f}",
+                        style=delta_color(contract.delta),
+                    )
+                else:
+                    delta_cell = ""
                 row.extend(
                     [
-                        f"{contract.delta:.3f}" if contract.delta is not None else "",
+                        delta_cell,
                         f"{contract.gamma:.3f}" if contract.gamma is not None else "",
                         f"{contract.theta:.3f}" if contract.theta is not None else "",
                         f"{contract.vega:.3f}" if contract.vega is not None else "",
@@ -169,6 +281,29 @@ class ChainTable(Widget):
             row_count += 1
 
         return atm_row_idx
+
+    def on_data_table_header_selected(self, event: DataTable.HeaderSelected) -> None:
+        """Toggle sort on column header click."""
+        col_key = event.column_key.value
+        if self._sort_column == col_key and not self._sort_reverse:
+            self._sort_reverse = True
+        elif self._sort_column == col_key and self._sort_reverse:
+            self._sort_column = None
+            self._sort_reverse = False
+        else:
+            self._sort_column = col_key
+            self._sort_reverse = False
+        if self._last_chain is not None:
+            import asyncio
+
+            asyncio.ensure_future(
+                self.display_chain(
+                    self._last_chain,
+                    self._last_price,
+                    self._last_thresholds,
+                    earnings_date=self._last_earnings_date,
+                )
+            )
 
     def _center_on_row(self, table: DataTable, row_idx: int) -> None:
         """Scroll so the given row is centered in the table's viewport."""

--- a/tests/test_chain_filters.py
+++ b/tests/test_chain_filters.py
@@ -5,7 +5,12 @@ import pytest
 from tenortui.chain_filters import (
     ChainFilters,
     SORT_KEYS,
+    compute_chain_median,
+    delta_color,
     filter_contracts,
+    is_high_activity,
+    iv_color,
+    iv_percentile_rank,
     parse_filter_command,
     sort_contracts,
 )
@@ -423,3 +428,96 @@ class TestParseFilterCommand:
     def test_empty_string_returns_none(self):
         result = parse_filter_command("")
         assert result is None
+
+
+# ===========================================================================
+# Task 4: TestVisualHelpers
+# ===========================================================================
+
+
+class TestVisualHelpers:
+    # iv_percentile_rank
+    def test_iv_percentile_rank_basic(self):
+        all_ivs = [0.10, 0.20, 0.30, 0.40, 0.50]
+        rank = iv_percentile_rank(0.30, all_ivs)
+        assert 0.0 <= rank <= 1.0
+
+    def test_iv_percentile_rank_min(self):
+        all_ivs = [0.10, 0.20, 0.30]
+        rank = iv_percentile_rank(0.10, all_ivs)
+        assert rank == pytest.approx(0.0)
+
+    def test_iv_percentile_rank_max(self):
+        all_ivs = [0.10, 0.20, 0.30]
+        rank = iv_percentile_rank(0.30, all_ivs)
+        assert rank == pytest.approx(1.0)
+
+    def test_iv_percentile_rank_single_element(self):
+        rank = iv_percentile_rank(0.25, [0.25])
+        assert rank == pytest.approx(0.0)
+
+    def test_iv_percentile_rank_empty_list(self):
+        rank = iv_percentile_rank(0.25, [])
+        assert rank == pytest.approx(0.0)
+
+    # compute_chain_median
+    def test_compute_chain_median_odd(self):
+        result = compute_chain_median([1, 3, 5])
+        assert result == pytest.approx(3.0)
+
+    def test_compute_chain_median_even(self):
+        result = compute_chain_median([1, 2, 3, 4])
+        assert result == pytest.approx(2.5)
+
+    def test_compute_chain_median_empty(self):
+        result = compute_chain_median([])
+        assert result == pytest.approx(0.0)
+
+    # is_high_activity
+    def test_is_high_activity_true(self):
+        assert is_high_activity(1000, 400) is True  # 1000 > 2*400
+
+    def test_is_high_activity_false(self):
+        assert is_high_activity(500, 400) is False  # 500 <= 2*400
+
+    def test_is_high_activity_boundary(self):
+        assert is_high_activity(800, 400) is False  # 800 == 2*400, not strictly greater
+
+    # delta_color
+    def test_delta_color_high(self):
+        assert delta_color(0.70) == "green"
+        assert delta_color(-0.75) == "green"  # abs(-0.75) >= 0.7
+
+    def test_delta_color_medium(self):
+        assert delta_color(0.50) == "yellow"
+        assert delta_color(-0.40) == "yellow"
+
+    def test_delta_color_low(self):
+        assert delta_color(0.10) == "red"
+        assert delta_color(-0.05) == "red"
+
+    def test_delta_color_boundary_0_7(self):
+        assert delta_color(0.70) == "green"
+
+    def test_delta_color_boundary_0_3(self):
+        assert delta_color(0.30) == "yellow"
+
+    def test_delta_color_none(self):
+        assert delta_color(None) == ""
+
+    # iv_color
+    def test_iv_color_low_percentile(self):
+        assert iv_color(0.25) == "cyan"
+        assert iv_color(0.0) == "cyan"
+
+    def test_iv_color_medium_low(self):
+        assert iv_color(0.50) == "yellow"
+        assert iv_color(0.26) == "yellow"
+
+    def test_iv_color_medium_high(self):
+        assert iv_color(0.75) == "dark_orange"
+        assert iv_color(0.51) == "dark_orange"
+
+    def test_iv_color_high(self):
+        assert iv_color(0.76) == "red"
+        assert iv_color(1.0) == "red"

--- a/tests/test_chain_filters.py
+++ b/tests/test_chain_filters.py
@@ -1,0 +1,226 @@
+"""Tests for chain_filters module: filtering, sorting, command parsing, visual helpers."""
+
+from tenortui.chain_filters import (
+    ChainFilters,
+    filter_contracts,
+)
+from tenortui.models import OptionContract
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _make_contract(
+    strike: float,
+    option_type: str = "call",
+    volume: int = 100,
+    open_interest: int = 500,
+    iv: float = 0.30,
+    delta: float | None = None,
+) -> OptionContract:
+    return OptionContract(
+        contract_symbol=f"TEST{strike}{option_type[0].upper()}",
+        option_type=option_type,
+        strike=strike,
+        bid=1.0,
+        ask=1.5,
+        last_price=1.25,
+        volume=volume,
+        open_interest=open_interest,
+        implied_volatility=iv,
+        delta=delta,
+        gamma=0.05 if delta is not None else None,
+        theta=-0.03 if delta is not None else None,
+        vega=0.15 if delta is not None else None,
+        rho=0.01 if delta is not None else None,
+    )
+
+
+# ===========================================================================
+# Task 1: TestFilterContracts
+# ===========================================================================
+
+
+class TestFilterContracts:
+    def test_no_filters_returns_all(self):
+        contracts = [_make_contract(100), _make_contract(110), _make_contract(120)]
+        result = filter_contracts(contracts, ChainFilters())
+        assert result == contracts
+
+    def test_min_volume_hides_zero_volume(self):
+        contracts = [
+            _make_contract(100, volume=0),
+            _make_contract(110, volume=50),
+            _make_contract(120, volume=200),
+        ]
+        result = filter_contracts(contracts, ChainFilters(min_volume=1))
+        strikes = [c.strike for c in result]
+        assert 100 not in strikes
+        assert 110 in strikes
+        assert 120 in strikes
+
+    def test_min_volume_hides_low_volume(self):
+        contracts = [
+            _make_contract(100, volume=10),
+            _make_contract(110, volume=100),
+            _make_contract(120, volume=200),
+        ]
+        result = filter_contracts(contracts, ChainFilters(min_volume=100))
+        strikes = [c.strike for c in result]
+        assert 100 not in strikes
+        assert 110 in strikes
+        assert 120 in strikes
+
+    def test_moneyness_itm_calls(self):
+        # For calls, ITM means strike < current_price
+        contracts = [
+            _make_contract(90, option_type="call"),  # ITM (strike < 100)
+            _make_contract(100, option_type="call"),  # ATM
+            _make_contract(110, option_type="call"),  # OTM
+        ]
+        result = filter_contracts(
+            contracts, ChainFilters(moneyness="itm"), current_price=100, side="call"
+        )
+        strikes = [c.strike for c in result]
+        assert 90 in strikes
+        assert 100 not in strikes
+        assert 110 not in strikes
+
+    def test_moneyness_itm_puts(self):
+        # For puts, ITM means strike > current_price
+        contracts = [
+            _make_contract(90, option_type="put"),  # OTM
+            _make_contract(100, option_type="put"),  # ATM
+            _make_contract(110, option_type="put"),  # ITM (strike > 100)
+        ]
+        result = filter_contracts(
+            contracts, ChainFilters(moneyness="itm"), current_price=100, side="put"
+        )
+        strikes = [c.strike for c in result]
+        assert 90 not in strikes
+        assert 100 not in strikes
+        assert 110 in strikes
+
+    def test_moneyness_otm_calls(self):
+        contracts = [
+            _make_contract(90, option_type="call"),  # ITM
+            _make_contract(100, option_type="call"),  # ATM
+            _make_contract(110, option_type="call"),  # OTM
+        ]
+        result = filter_contracts(
+            contracts, ChainFilters(moneyness="otm"), current_price=100, side="call"
+        )
+        strikes = [c.strike for c in result]
+        assert 90 not in strikes
+        assert 100 not in strikes
+        assert 110 in strikes
+
+    def test_moneyness_otm_puts(self):
+        contracts = [
+            _make_contract(90, option_type="put"),  # OTM (strike < price)
+            _make_contract(100, option_type="put"),  # ATM
+            _make_contract(110, option_type="put"),  # ITM
+        ]
+        result = filter_contracts(
+            contracts, ChainFilters(moneyness="otm"), current_price=100, side="put"
+        )
+        strikes = [c.strike for c in result]
+        assert 90 in strikes
+        assert 100 not in strikes
+        assert 110 not in strikes
+
+    def test_min_delta_filters_out_low_abs_delta(self):
+        contracts = [
+            _make_contract(100, delta=0.10),
+            _make_contract(110, delta=0.30),
+            _make_contract(120, delta=0.70),
+        ]
+        result = filter_contracts(contracts, ChainFilters(min_delta=0.25))
+        strikes = [c.strike for c in result]
+        assert 100 not in strikes
+        assert 110 in strikes
+        assert 120 in strikes
+
+    def test_max_delta_filters_out_high_abs_delta(self):
+        contracts = [
+            _make_contract(100, delta=0.10),
+            _make_contract(110, delta=0.50),
+            _make_contract(120, delta=0.90),
+        ]
+        result = filter_contracts(contracts, ChainFilters(max_delta=0.60))
+        strikes = [c.strike for c in result]
+        assert 100 in strikes
+        assert 110 in strikes
+        assert 120 not in strikes
+
+    def test_delta_range_combined(self):
+        contracts = [
+            _make_contract(100, delta=0.10),
+            _make_contract(110, delta=0.40),
+            _make_contract(120, delta=0.80),
+        ]
+        result = filter_contracts(
+            contracts, ChainFilters(min_delta=0.30, max_delta=0.60)
+        )
+        strikes = [c.strike for c in result]
+        assert 100 not in strikes
+        assert 110 in strikes
+        assert 120 not in strikes
+
+    def test_min_oi_threshold(self):
+        contracts = [
+            _make_contract(100, open_interest=50),
+            _make_contract(110, open_interest=200),
+            _make_contract(120, open_interest=1000),
+        ]
+        result = filter_contracts(contracts, ChainFilters(min_oi=100))
+        strikes = [c.strike for c in result]
+        assert 100 not in strikes
+        assert 110 in strikes
+        assert 120 in strikes
+
+    def test_combined_filters(self):
+        contracts = [
+            _make_contract(90, volume=5, open_interest=50, delta=0.10),
+            _make_contract(100, volume=200, open_interest=500, delta=0.50),
+            _make_contract(110, volume=150, open_interest=800, delta=0.80),
+        ]
+        result = filter_contracts(
+            contracts,
+            ChainFilters(min_volume=100, min_oi=200, min_delta=0.30, max_delta=0.70),
+        )
+        strikes = [c.strike for c in result]
+        assert 90 not in strikes  # fails volume, oi, delta
+        assert 100 in strikes  # passes all
+        assert 110 not in strikes  # fails max_delta
+
+    def test_delta_filter_skips_none_delta(self):
+        contracts = [
+            _make_contract(100, delta=None),
+            _make_contract(110, delta=0.50),
+        ]
+        result = filter_contracts(contracts, ChainFilters(min_delta=0.30))
+        strikes = [c.strike for c in result]
+        # Contract with None delta should be excluded when delta filter is active
+        assert 100 not in strikes
+        assert 110 in strikes
+
+    def test_chain_filters_is_active_false_when_empty(self):
+        f = ChainFilters()
+        assert f.is_active is False
+
+    def test_chain_filters_is_active_true_when_any_set(self):
+        assert ChainFilters(min_volume=1).is_active is True
+        assert ChainFilters(min_oi=1).is_active is True
+        assert ChainFilters(min_delta=0.1).is_active is True
+        assert ChainFilters(max_delta=0.9).is_active is True
+        assert ChainFilters(moneyness="itm").is_active is True
+
+    def test_chain_filters_active_count(self):
+        f = ChainFilters(min_volume=1, min_oi=100)
+        assert f.active_count == 2
+
+    def test_chain_filters_active_count_zero_when_empty(self):
+        assert ChainFilters().active_count == 0

--- a/tests/test_chain_filters.py
+++ b/tests/test_chain_filters.py
@@ -1,9 +1,12 @@
 """Tests for chain_filters module: filtering, sorting, command parsing, visual helpers."""
 
+import pytest
+
 from tenortui.chain_filters import (
     ChainFilters,
     SORT_KEYS,
     filter_contracts,
+    parse_filter_command,
     sort_contracts,
 )
 from tenortui.models import OptionContract
@@ -365,3 +368,58 @@ class TestSortContracts:
             "rho",
         }
         assert expected.issubset(set(SORT_KEYS.keys()))
+
+
+# ===========================================================================
+# Task 3: TestParseFilterCommand
+# ===========================================================================
+
+
+class TestParseFilterCommand:
+    def test_volume_gt_0(self):
+        result = parse_filter_command("volume > 0")
+        assert result is not None
+        assert result.min_volume == 1
+
+    def test_volume_gt_100(self):
+        result = parse_filter_command("volume > 100")
+        assert result is not None
+        assert result.min_volume == 101
+
+    def test_vol_alias(self):
+        result = parse_filter_command("vol > 50")
+        assert result is not None
+        assert result.min_volume == 51
+
+    def test_oi_gt_100(self):
+        result = parse_filter_command("oi > 100")
+        assert result is not None
+        assert result.min_oi == 101
+
+    def test_moneyness_itm(self):
+        result = parse_filter_command("itm")
+        assert result is not None
+        assert result.moneyness == "itm"
+
+    def test_moneyness_otm(self):
+        result = parse_filter_command("otm")
+        assert result is not None
+        assert result.moneyness == "otm"
+
+    def test_delta_range(self):
+        result = parse_filter_command("delta 0.2 0.8")
+        assert result is not None
+        assert result.min_delta == pytest.approx(0.2)
+        assert result.max_delta == pytest.approx(0.8)
+
+    def test_clear_returns_none(self):
+        result = parse_filter_command("clear")
+        assert result is None
+
+    def test_invalid_returns_none(self):
+        result = parse_filter_command("foobar xyz")
+        assert result is None
+
+    def test_empty_string_returns_none(self):
+        result = parse_filter_command("")
+        assert result is None

--- a/tests/test_chain_filters.py
+++ b/tests/test_chain_filters.py
@@ -2,7 +2,9 @@
 
 from tenortui.chain_filters import (
     ChainFilters,
+    SORT_KEYS,
     filter_contracts,
+    sort_contracts,
 )
 from tenortui.models import OptionContract
 
@@ -224,3 +226,142 @@ class TestFilterContracts:
 
     def test_chain_filters_active_count_zero_when_empty(self):
         assert ChainFilters().active_count == 0
+
+
+# ===========================================================================
+# Task 2: TestSortContracts
+# ===========================================================================
+
+
+class TestSortContracts:
+    def test_sort_by_strike_asc(self):
+        contracts = [_make_contract(120), _make_contract(100), _make_contract(110)]
+        result = sort_contracts(contracts, "strike", reverse=False)
+        assert [c.strike for c in result] == [100, 110, 120]
+
+    def test_sort_by_strike_desc(self):
+        contracts = [_make_contract(120), _make_contract(100), _make_contract(110)]
+        result = sort_contracts(contracts, "strike", reverse=True)
+        assert [c.strike for c in result] == [120, 110, 100]
+
+    def test_sort_by_volume(self):
+        contracts = [
+            _make_contract(100, volume=300),
+            _make_contract(110, volume=100),
+            _make_contract(120, volume=200),
+        ]
+        result = sort_contracts(contracts, "vol")
+        assert [c.volume for c in result] == [100, 200, 300]
+
+    def test_sort_by_oi(self):
+        contracts = [
+            _make_contract(100, open_interest=900),
+            _make_contract(110, open_interest=100),
+            _make_contract(120, open_interest=500),
+        ]
+        result = sort_contracts(contracts, "oi")
+        assert [c.open_interest for c in result] == [100, 500, 900]
+
+    def test_sort_by_iv(self):
+        contracts = [
+            _make_contract(100, iv=0.50),
+            _make_contract(110, iv=0.20),
+            _make_contract(120, iv=0.35),
+        ]
+        result = sort_contracts(contracts, "iv")
+        assert [c.implied_volatility for c in result] == [0.20, 0.35, 0.50]
+
+    def test_sort_by_delta(self):
+        contracts = [
+            _make_contract(100, delta=0.70),
+            _make_contract(110, delta=0.30),
+            _make_contract(120, delta=0.50),
+        ]
+        result = sort_contracts(contracts, "delta")
+        assert [c.delta for c in result] == [0.30, 0.50, 0.70]
+
+    def test_none_delta_sorts_to_end(self):
+        contracts = [
+            _make_contract(100, delta=None),
+            _make_contract(110, delta=0.50),
+            _make_contract(120, delta=0.20),
+        ]
+        result = sort_contracts(contracts, "delta")
+        assert result[-1].strike == 100  # None delta goes to end
+        assert result[0].delta == 0.20
+
+    def test_none_column_defaults_to_strike_sort(self):
+        contracts = [_make_contract(120), _make_contract(100), _make_contract(110)]
+        result = sort_contracts(contracts, None)
+        assert [c.strike for c in result] == [100, 110, 120]
+
+    def test_sort_by_bid(self):
+        c1 = OptionContract(
+            contract_symbol="A",
+            option_type="call",
+            strike=100,
+            bid=3.0,
+            ask=3.5,
+            last_price=3.2,
+            volume=100,
+            open_interest=500,
+            implied_volatility=0.3,
+            delta=None,
+            gamma=None,
+            theta=None,
+            vega=None,
+            rho=None,
+        )
+        c2 = OptionContract(
+            contract_symbol="B",
+            option_type="call",
+            strike=110,
+            bid=1.0,
+            ask=1.5,
+            last_price=1.2,
+            volume=100,
+            open_interest=500,
+            implied_volatility=0.3,
+            delta=None,
+            gamma=None,
+            theta=None,
+            vega=None,
+            rho=None,
+        )
+        c3 = OptionContract(
+            contract_symbol="C",
+            option_type="call",
+            strike=120,
+            bid=2.0,
+            ask=2.5,
+            last_price=2.2,
+            volume=100,
+            open_interest=500,
+            implied_volatility=0.3,
+            delta=None,
+            gamma=None,
+            theta=None,
+            vega=None,
+            rho=None,
+        )
+        result = sort_contracts([c1, c2, c3], "bid")
+        assert [c.bid for c in result] == [1.0, 2.0, 3.0]
+
+    def test_sort_keys_has_expected_columns(self):
+        expected = {
+            "strike",
+            "bid",
+            "ask",
+            "spread",
+            "mid",
+            "last",
+            "vol",
+            "oi",
+            "iv",
+            "delta",
+            "gamma",
+            "theta",
+            "vega",
+            "rho",
+        }
+        assert expected.issubset(set(SORT_KEYS.keys()))

--- a/tests/test_chain_table_enhanced.py
+++ b/tests/test_chain_table_enhanced.py
@@ -186,8 +186,8 @@ async def test_chain_table_iv_color_applied():
 
 
 @pytest.mark.asyncio
-async def test_chain_table_high_volume_bold():
-    """Renders without error with high-volume contracts (bold applied)."""
+async def test_chain_table_high_volume_highlight():
+    """Renders without error with high-volume contracts (color tint applied)."""
     chain = _make_chain(
         calls=[
             _make_contract(100.0, volume=10),

--- a/tests/test_chain_table_enhanced.py
+++ b/tests/test_chain_table_enhanced.py
@@ -1,0 +1,378 @@
+"""Tests for enhanced ChainTable: filtering, sorting, visual highlights,
+sort toggle, sort indicators, and earnings warnings."""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import DataTable
+
+from tenortui.chain_filters import ChainFilters, parse_filter_command
+from tenortui.models import OptionContract, OptionsChain
+from tenortui.widgets.chain_table import ChainTable
+
+
+class WidgetTestApp(App):
+    def __init__(self, widget):
+        super().__init__()
+        self._widget = widget
+
+    def compose(self) -> ComposeResult:
+        yield self._widget
+
+
+def _make_contract(
+    strike,
+    option_type="call",
+    volume=100,
+    open_interest=500,
+    iv=0.30,
+    delta=None,
+    gamma=None,
+    theta=None,
+    vega=None,
+    rho=None,
+):
+    return OptionContract(
+        contract_symbol=f"TEST{strike}{option_type[0].upper()}",
+        option_type=option_type,
+        strike=strike,
+        bid=1.0,
+        ask=1.5,
+        last_price=1.25,
+        volume=volume,
+        open_interest=open_interest,
+        implied_volatility=iv,
+        delta=delta,
+        gamma=gamma,
+        theta=theta,
+        vega=vega,
+        rho=rho,
+    )
+
+
+def _make_chain(calls=None, puts=None):
+    return OptionsChain(
+        symbol="TEST",
+        expiration="2026-04-17",
+        calls=calls or [],
+        puts=puts or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 5: Filtering / Sorting integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chain_table_with_filters():
+    """Filters hide zero-volume contracts."""
+    chain = _make_chain(
+        calls=[
+            _make_contract(100.0, volume=0),
+            _make_contract(110.0, volume=500),
+            _make_contract(120.0, volume=200),
+        ],
+    )
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        widget.set_filters(ChainFilters(min_volume=1))
+        await widget.display_chain(chain, current_price=115.0)
+        tables = widget.query(DataTable)
+        calls_table = tables.first()
+        # The zero-volume contract should be filtered out.
+        # We expect 2 data rows + 1 ATM row = 3 total rows.
+        assert calls_table.row_count == 3
+
+
+@pytest.mark.asyncio
+async def test_chain_table_sort_by_volume():
+    """Sorting by volume works and suppresses ATM divider."""
+    chain = _make_chain(
+        calls=[
+            _make_contract(100.0, volume=50),
+            _make_contract(110.0, volume=500),
+            _make_contract(120.0, volume=200),
+        ],
+    )
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        widget.set_sort("vol", reverse=True)
+        await widget.display_chain(chain, current_price=115.0)
+        tables = widget.query(DataTable)
+        calls_table = tables.first()
+        # No ATM divider when sorted by non-strike column
+        assert calls_table.row_count == 3
+
+
+@pytest.mark.asyncio
+async def test_chain_table_filter_clear():
+    """clear_filters resets to no filtering."""
+    chain = _make_chain(
+        calls=[
+            _make_contract(100.0, volume=0),
+            _make_contract(110.0, volume=500),
+        ],
+    )
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        widget.set_filters(ChainFilters(min_volume=1))
+        await widget.display_chain(chain, current_price=105.0)
+        tables = widget.query(DataTable)
+        calls_table = tables.first()
+        # 1 contract + ATM row = 2
+        assert calls_table.row_count == 2
+
+        # Clear filters and re-render
+        widget.clear_filters()
+        await widget.display_chain(chain, current_price=105.0)
+        tables = widget.query(DataTable)
+        calls_table = tables.first()
+        # 2 contracts + ATM row = 3
+        assert calls_table.row_count == 3
+
+
+@pytest.mark.asyncio
+async def test_chain_table_earnings_warning():
+    """Section label shows earnings warning when earnings_date is set."""
+    chain = _make_chain(calls=[_make_contract(100.0)])
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        await widget.display_chain(chain, current_price=95.0, earnings_date="Apr 25")
+        labels = widget.query(".section-label")
+        calls_label = str(labels.first().render().plain)
+        assert "Earnings: Apr 25" in calls_label
+
+
+@pytest.mark.asyncio
+async def test_chain_table_filter_count_in_label():
+    """Section label shows filter count when filters are active."""
+    chain = _make_chain(calls=[_make_contract(100.0, volume=100)])
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        widget.set_filters(ChainFilters(min_volume=10, min_oi=5))
+        await widget.display_chain(chain, current_price=95.0)
+        labels = widget.query(".section-label")
+        calls_label = str(labels.first().render().plain)
+        assert "(2 filters)" in calls_label
+
+
+# ---------------------------------------------------------------------------
+# Task 6: Visual Highlights
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chain_table_iv_color_applied():
+    """Renders without error with varying IVs (IV color coding applied)."""
+    chain = _make_chain(
+        calls=[
+            _make_contract(100.0, iv=0.10),
+            _make_contract(110.0, iv=0.50),
+            _make_contract(120.0, iv=0.90),
+        ],
+    )
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        await widget.display_chain(chain, current_price=115.0)
+        tables = widget.query(DataTable)
+        # Just verify it rendered without error and has rows
+        assert tables.first().row_count > 0
+
+
+@pytest.mark.asyncio
+async def test_chain_table_high_volume_bold():
+    """Renders without error with high-volume contracts (bold applied)."""
+    chain = _make_chain(
+        calls=[
+            _make_contract(100.0, volume=10),
+            _make_contract(110.0, volume=10),
+            _make_contract(120.0, volume=10000),  # far above median
+        ],
+    )
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        await widget.display_chain(chain, current_price=115.0)
+        tables = widget.query(DataTable)
+        assert tables.first().row_count > 0
+
+
+@pytest.mark.asyncio
+async def test_chain_table_delta_color_applied():
+    """Renders with greeks present and delta color applied."""
+    chain = _make_chain(
+        calls=[
+            _make_contract(
+                100.0, delta=0.8, gamma=0.02, theta=-0.05, vega=0.1, rho=0.01
+            ),
+            _make_contract(
+                110.0, delta=0.5, gamma=0.04, theta=-0.03, vega=0.15, rho=0.02
+            ),
+            _make_contract(
+                120.0, delta=0.2, gamma=0.01, theta=-0.01, vega=0.05, rho=0.005
+            ),
+        ],
+    )
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        await widget.display_chain(chain, current_price=115.0)
+        tables = widget.query(DataTable)
+        assert tables.first().row_count > 0
+
+
+# ---------------------------------------------------------------------------
+# Task 7: Wire Filter Commands in App (parse_filter_command integration)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_filter_command_volume_integration():
+    """parse_filter_command returns correct ChainFilters for volume filter."""
+    result = parse_filter_command("vol > 100")
+    assert result is not None
+    assert result.min_volume == 101
+    assert result.is_active
+
+
+def test_parse_filter_command_clear_integration():
+    """parse_filter_command returns None for 'clear'."""
+    result = parse_filter_command("clear")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Task 8: Column Header Sort Toggle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chain_table_sort_toggle():
+    """Verify set_sort state changes cycle correctly."""
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        # Initially no sort
+        assert widget._sort_column is None
+        assert widget._sort_reverse is False
+
+        # Set sort ascending
+        widget.set_sort("vol", reverse=False)
+        assert widget._sort_column == "vol"
+        assert widget._sort_reverse is False
+
+        # Set sort descending
+        widget.set_sort("vol", reverse=True)
+        assert widget._sort_column == "vol"
+        assert widget._sort_reverse is True
+
+        # Clear sort
+        widget.set_sort(None)
+        assert widget._sort_column is None
+        assert widget._sort_reverse is False
+
+
+@pytest.mark.asyncio
+async def test_chain_table_header_selected_toggle():
+    """on_data_table_header_selected toggles sort state."""
+    chain = _make_chain(
+        calls=[
+            _make_contract(100.0, volume=50),
+            _make_contract(110.0, volume=500),
+        ],
+    )
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        await widget.display_chain(chain, current_price=105.0)
+        # Initially no custom sort
+        assert widget._sort_column is None
+
+        # Simulate header click on "vol"
+        tables = widget.query(DataTable)
+        calls_table = tables.first()
+        # Find the vol column key
+        vol_col = None
+        for col in calls_table.columns.values():
+            if col.key.value == "vol":
+                vol_col = col
+                break
+        assert vol_col is not None
+
+        # First click -> ascending
+        event = DataTable.HeaderSelected(
+            calls_table, vol_col.key, column_index=0, label=vol_col.label
+        )
+        widget.on_data_table_header_selected(event)
+        assert widget._sort_column == "vol"
+        assert widget._sort_reverse is False
+
+        # Second click -> descending
+        widget.on_data_table_header_selected(event)
+        assert widget._sort_column == "vol"
+        assert widget._sort_reverse is True
+
+        # Third click -> clear
+        widget.on_data_table_header_selected(event)
+        assert widget._sort_column is None
+        assert widget._sort_reverse is False
+
+
+# ---------------------------------------------------------------------------
+# Task 9: Sort Direction Indicators
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chain_table_sort_indicator_in_header():
+    """Ascending sort shows up-arrow in column header."""
+    chain = _make_chain(calls=[_make_contract(100.0)])
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        widget.set_sort("vol", reverse=False)
+        await widget.display_chain(chain, current_price=95.0)
+        tables = widget.query(DataTable)
+        calls_table = tables.first()
+        col_labels = [str(col.label) for col in calls_table.columns.values()]
+        vol_labels = [lbl for lbl in col_labels if "Vol" in lbl]
+        assert len(vol_labels) == 1
+        assert "\u25b2" in vol_labels[0]  # up arrow
+
+
+@pytest.mark.asyncio
+async def test_chain_table_sort_indicator_descending():
+    """Descending sort shows down-arrow in column header."""
+    chain = _make_chain(calls=[_make_contract(100.0)])
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        widget.set_sort("vol", reverse=True)
+        await widget.display_chain(chain, current_price=95.0)
+        tables = widget.query(DataTable)
+        calls_table = tables.first()
+        col_labels = [str(col.label) for col in calls_table.columns.values()]
+        vol_labels = [lbl for lbl in col_labels if "Vol" in lbl]
+        assert len(vol_labels) == 1
+        assert "\u25bc" in vol_labels[0]  # down arrow
+
+
+@pytest.mark.asyncio
+async def test_chain_table_no_sort_indicator_when_unsorted():
+    """No arrow indicators when sort is not active."""
+    chain = _make_chain(calls=[_make_contract(100.0)])
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        await widget.display_chain(chain, current_price=95.0)
+        tables = widget.query(DataTable)
+        calls_table = tables.first()
+        col_labels = [str(col.label) for col in calls_table.columns.values()]
+        for label in col_labels:
+            assert "\u25b2" not in label
+            assert "\u25bc" not in label

--- a/tests/test_chain_table_enhanced.py
+++ b/tests/test_chain_table_enhanced.py
@@ -376,3 +376,43 @@ async def test_chain_table_no_sort_indicator_when_unsorted():
         for label in col_labels:
             assert "\u25b2" not in label
             assert "\u25bc" not in label
+
+
+# ---------------------------------------------------------------------------
+# Task 10: Full integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_full_enhanced_chain_workflow():
+    """Integration test: filter + sort + visual highlights all work together."""
+    chain = OptionsChain(
+        symbol="TEST",
+        expiration="2026-04-17",
+        calls=[
+            _make_contract(100, volume=0, iv=0.10, delta=0.9),
+            _make_contract(110, volume=50, iv=0.25, delta=0.5),
+            _make_contract(120, volume=1000, iv=0.50, delta=0.1),
+        ],
+        puts=[
+            _make_contract(100, "put", volume=30, iv=0.15, delta=-0.1),
+            _make_contract(110, "put", volume=200, iv=0.30, delta=-0.5),
+        ],
+    )
+    widget = ChainTable()
+    app = WidgetTestApp(widget)
+    async with app.run_test():
+        widget.set_filters(ChainFilters(min_volume=1))
+        widget.set_sort("iv", reverse=True)
+        await widget.display_chain(chain, current_price=115.0, earnings_date="Apr 10")
+        tables = widget.query(DataTable)
+        calls_table = tables.first()
+        # Filtered out volume=0, so 2 calls remain.
+        # No ATM divider row because sort is active (divider only shown when
+        # sorted by strike).
+        assert calls_table.row_count == 2
+
+        # Check section label has earnings warning
+        labels = widget.query(".section-label")
+        calls_label = str(labels.first().render().plain)
+        assert "Earnings" in calls_label


### PR DESCRIPTION
## Summary
- Column sorting with direction indicators (▲/▼) via header click
- Filtering via command palette: `:filter volume > 0`, `:filter itm`, `:filter delta 0.2 0.8`, `:filter oi > 100`, `:filter clear`
- IV color-coding (cool→warm gradient based on percentile rank)
- High-volume/OI bold highlighting (> 2x median)
- Delta color gradient (green=ITM, yellow=ATM, red=OTM)
- Earnings warning indicator in section labels

Closes #14

*Co-authored by Claude*

## Test plan
- [ ] Run `poetry run python -m pytest -v` — all tests pass
- [ ] Manual test: load a ticker, verify IV colors appear
- [ ] Manual test: click column headers to sort, verify arrows
- [ ] Manual test: `:filter volume > 0` hides zero-volume strikes
- [ ] Manual test: `:filter itm` / `:filter otm` works correctly
- [ ] Manual test: `:filter clear` resets to full chain
- [ ] Manual test with Tradier: delta colors show green/yellow/red gradient

🤖 Generated with [Claude Code](https://claude.com/claude-code)