### PR TITLE
Plan B: PyPI distribution + 1.0.0 release (#49)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,3 +94,21 @@ jobs:
 
       - name: Build docs (strict)
         run: cd docs/site && poetry run mkdocs build --strict
+
+  check-version-bump:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Run version-bump / changelog check
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: python bin/check-version-bump --base "origin/$BASE_REF"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  should-release:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.detect.outputs.version }}
+      needs_release: ${{ steps.detect.outputs.needs_release }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect version and tag
+        id: detect
+        run: |
+          VERSION=$(grep -E '^version' pyproject.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists — skipping release."
+            echo "needs_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag v$VERSION does not exist — release will run."
+            echo "needs_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  release:
+    needs: should-release
+    if: needs.should-release.outputs.needs_release == 'true'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      VERSION: ${{ needs.should-release.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-in-project: true
+
+      - name: Install dependencies and run tests
+        run: |
+          poetry install
+          poetry run python -m pytest
+
+      - name: Build wheel and sdist
+        run: poetry build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Tag the release
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+
+      - name: Extract release notes from CHANGELOG
+        run: python bin/changelog-section "$VERSION" > /tmp/release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "v$VERSION" dist/* --notes-file /tmp/release-notes.md --title "v$VERSION"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,3 +40,9 @@ versioned section at release time.
   a GitHub Release with the wheel + sdist attached.
 - `bin/changelog-section` — extracts a `## [<version>]` section's body for
   use as GitHub Release notes.
+
+### Changed
+
+- README rewritten as a developer/install/contribute landing (under 80 lines,
+  badges + install + dev workflow + contribute). Feature walkthroughs now
+  live on the docs site.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,9 @@ versioned section at release time.
 - `docs-build` CI job runs `mkdocs build --strict` on every PR.
 - `CLAUDE.md` Documentation Sync section: every change must update its
   relevant doc surface in the same PR.
+- Full PyPI metadata in `pyproject.toml` (license, authors, URLs, classifiers,
+  keywords) — wheel passes `twine check`.
+- MIT `LICENSE` file at the repo root.
+- `bin/check-version-bump` — CI gate that requires every PR to add a
+  CHANGELOG `[Unreleased]` entry, or bump the version with a matching
+  `[<version>]` section. Dependabot exempt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,8 @@ versioned section at release time.
 - `bin/check-version-bump` — CI gate that requires every PR to add a
   CHANGELOG `[Unreleased]` entry, or bump the version with a matching
   `[<version>]` section. Dependabot exempt.
+- `.github/workflows/release.yml` — auto-publishes to PyPI via Trusted
+  Publishing (OIDC) on merges that bump the version, then tags and creates
+  a GitHub Release with the wheel + sdist attached.
+- `bin/changelog-section` — extracts a `## [<version>]` section's body for
+  use as GitHub Release notes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,19 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
-once the first PyPI release ships.
-
-Until then, entries land under `[Unreleased]` and roll into the first
-versioned section at release time.
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-04-27
+
+First public PyPI release. Marks TenorTUI as a stable shipped product.
+
 ### Added
 
-- MkDocs Material documentation site at `docs/site/`, deployed to GitHub
+- **PyPI distribution.** `pip install tenor-tui` (or `pipx install`) works
+  from PyPI.
+- **MkDocs Material documentation site** at `docs/site/`, deployed to GitHub
   Pages on every merge to `main` (`.github/workflows/docs.yml`). Live at
   <https://jayravaliya.com/tenor-tui/>.
 - `FixtureProvider` (`--provider fixture`) returning deterministic data for

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jay Ravaliya
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,187 +1,64 @@
 # TenorTUI
 
-A terminal UI for browsing stock options chains — built for your data source, navigated with your vim muscle memory.
+[![PyPI](https://img.shields.io/pypi/v/tenor-tui.svg)](https://pypi.org/project/tenor-tui/)
+[![CI](https://github.com/jayrav13/tenor-tui/actions/workflows/ci.yml/badge.svg)](https://github.com/jayrav13/tenor-tui/actions/workflows/ci.yml)
+[![Python](https://img.shields.io/pypi/pyversions/tenor-tui.svg)](https://pypi.org/project/tenor-tui/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-TenorTUI is a data-source agnostic options chain viewer for the terminal. Plug in a provider and the UI adapts to what it offers: basic quotes with Yahoo Finance, full Greeks with Tradier, or your own custom provider. Navigation is vim-native throughout — `j`/`k` to scroll, `h`/`l` to switch panes, `g`/`G` to jump, `:` for the command palette.
+A terminal UI for browsing stock options chains. Live quotes, full options
+chains with Greeks, named watchlists, pluggable data providers — all in
+your terminal.
 
-## Features
+**Documentation, screenshots, and feature walkthrough:
+<https://jayravaliya.com/tenor-tui/>**
 
-- **Pluggable data providers** — Yahoo Finance out of the box (no config), Tradier for Greeks, or implement your own
-- **Vim-style navigation** — `j`/`k`/`g`/`G`/`h`/`l` plus a `:` command palette
-- **ATM strike detection** — automatically finds the at-the-money strike and centers it in the viewport
-- **Recently viewed tickers** — quick access to your last 10 symbols with live quotes on launch
+![TenorTUI showing AAPL options chain](docs/site/docs/assets/snapshots/hero.svg)
 
-## Quick Start
+## Install
 
-**Prerequisites:** Python 3.11+, git, [Poetry](https://python-poetry.org/docs/#installation)
+```bash
+pipx install tenor-tui     # recommended
+pip install tenor-tui      # alternative
+```
+
+Then run `tenortui`.
+
+Requires Python 3.11+. See [Installation](https://jayravaliya.com/tenor-tui/installation/)
+for from-source setup and provider configuration.
+
+## Develop
 
 ```bash
 git clone https://github.com/jayrav13/tenor-tui.git
 cd tenor-tui
-poetry install
+poetry install --with docs
+pre-commit install && pre-commit install --hook-type pre-push
 poetry run tenortui
 ```
 
-Yahoo Finance is the default provider and requires zero configuration.
-
-## Configuration
-
-TenorTUI looks for a config file at `~/.config/tenor/config.yaml` (falls back to `~/.tenorrc`).
-
-Configuration is **optional** — Yahoo Finance works without it. You only need a config file to use Tradier or change the default provider.
-
-```yaml
----
-# Which provider to use by default
-default: yahoo
-
-# Yahoo Finance — no configuration needed
-yahoo: {}
-
-# Tradier — requires an API key from developer.tradier.com
-tradier:
-  api_key: your-api-key-here
-  sandbox: false   # set to true to use the sandbox API
-```
-
-### Yahoo Finance
-
-No setup required. Provides quotes and options chains without Greeks.
-
-### Tradier
-
-1. Get an API key from [developer.tradier.com](https://developer.tradier.com)
-2. Add it to your config file (see example above)
-3. Run with `tenortui --provider tradier` or set `default: tradier` in your config
-
-Tradier provides full options data including Greeks (delta, gamma, theta, vega, rho). Greek columns appear automatically when available.
-
-### CLI Override
-
-Override the config file provider for a single session:
+Common commands:
 
 ```bash
-tenortui --provider tradier
+poetry run python -m pytest -v        # tests
+poetry run ruff check src/ tests/     # lint
+poetry run ruff format src/ tests/    # format
+make docs-serve                       # preview docs locally
+make snapshots && make demos          # regenerate UI screenshots/GIFs
 ```
 
-## Keybindings
+The full developer guide and contribution flow live in
+[`CLAUDE.md`](CLAUDE.md).
 
-Press `?` at any time to see the help overlay.
+## Contribute
 
-### Navigation
+Open an issue first (a checkbox-list of success criteria helps reviewers).
+Branch off `main` with `fix/<issue-number>-<short-desc>`, reference the issue
+in your commit messages (`Closes #N` or `Refs #N`), and update the docs
+surfaces called out in `CLAUDE.md`'s Documentation Sync table.
 
-| Key | Action |
-|-----|--------|
-| `j` / `k` | Move down / up in lists and tables |
-| `h` / `l` | Switch to previous / next pane |
-| `g` | Jump to top of list |
-| `G` | Jump to bottom of list |
-| `Tab` / `Shift+Tab` | Next / previous pane |
+Every PR must add a `CHANGELOG.md` entry under `[Unreleased]` (CI enforces
+this). Version bumps trigger an automatic PyPI release on merge.
 
-### Actions
+## License
 
-| Key | Action |
-|-----|--------|
-| `/` or `s` | Focus search bar |
-| `r` | Refresh current data |
-| `Enter` | Select / expand |
-| `q` | Quit |
-
-### Panels
-
-| Key | Action |
-|-----|--------|
-| `?` | Toggle help overlay |
-| `:` | Open command palette |
-
-### Command Palette
-
-Press `:` to open the command palette, then type a command:
-
-| Command | Action |
-|---------|--------|
-| `:quit` | Exit the app |
-| `:search AAPL` | Search for a ticker |
-| `:help` | Show help overlay |
-
-## Data Providers
-
-| Provider | Auth Required | Greeks |
-|----------|--------------|--------|
-| Yahoo Finance | No | No |
-| Tradier | Yes (API key) | Yes |
-
-### Adding Your Own Provider
-
-Providers implement the `DataProvider` protocol defined in `src/tenortui/providers/base.py`:
-
-```python
-class DataProvider(Protocol):
-    name: str
-
-    def get_quote(self, symbol: str) -> Quote: ...
-    def get_expirations(self, symbol: str) -> list[str]: ...
-    def get_chain(self, symbol: str, expiration: str) -> OptionsChain: ...
-```
-
-Implement these three methods, register your provider in `src/tenortui/providers/__init__.py`, and it's ready to use. Provider methods are synchronous — the app wraps them with `asyncio.to_thread()` to keep the UI responsive.
-
-## Development
-
-### Setup
-
-```bash
-git clone https://github.com/jayrav13/tenor-tui.git
-cd tenor-tui
-poetry install
-```
-
-### Commands
-
-```bash
-# Run the app
-poetry run tenortui
-
-# Run all tests
-poetry run python -m pytest -v
-
-# Run a single test
-poetry run python -m pytest tests/test_models.py::test_mid_price -v
-
-# Lint
-poetry run ruff check src/ tests/
-
-# Format (add --fix to auto-format)
-poetry run ruff format --check src/ tests/
-```
-
-### Architecture
-
-TenorTUI is built with [Textual](https://textual.textualize.io/), a modern Python TUI framework.
-
-**App flow:** On launch, recently viewed tickers are shown with live quotes. Selecting or searching a ticker fetches its quote and expiration dates, then loads the options chain for the nearest expiry. Switching expiry tabs loads a new chain.
-
-**Widget hierarchy:**
-- `TickerBar` — search input + quote display
-- `RecentlyViewed` — recently viewed tickers with live prices
-- `ExpirySelector` — tabbed expiration date selector
-- `ChainTable` — calls and puts tables with ATM divider
-- `StatusBar` — provider name and last refresh time
-- `CommandPalette` — vim-style `:` command input
-
-**Provider pattern:** Data providers are synchronous classes behind a Protocol interface. The app wraps all provider calls with `asyncio.to_thread()` so the UI stays responsive during network requests.
-
-**Config:** YAML config at `~/.config/tenor/config.yaml`. History stored at `~/.config/tenor/history.json` (last 10 tickers).
-
-See `CLAUDE.md` for the full development reference.
-
-## Built with Claude
-
-TenorTUI is a Claude-first project. Development is driven by [Claude Code](https://claude.ai/code), with structured workflows that enable parallel development across multiple features simultaneously.
-
-**How it works:**
-- Every change follows: GitHub Issue → git worktree → branch → PR → merge
-- Multiple Claude instances work on separate features in isolated worktrees
-- `CLAUDE.md` is the canonical development guide — it contains everything needed to understand the codebase, run tests, and follow the contribution workflow
-
-Contributions are welcome — both human and AI-assisted. Check the [GitHub Issues](https://github.com/jayrav13/tenor-tui/issues) for open tasks, and see `CLAUDE.md` for the full development workflow.
+[MIT](LICENSE).

--- a/bin/changelog-section
+++ b/bin/changelog-section
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Print the body of a `## [<version>]` section from CHANGELOG.md.
+
+Used by the release workflow to populate GitHub Release notes.
+
+Usage:
+  bin/changelog-section 1.0.0           # print body of `## [1.0.0]`
+  bin/changelog-section 1.0.0 --file CHANGELOG.md  # explicit file
+
+Exits 0 with the body on stdout, or 1 if the section is missing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SECTION_RE = re.compile(r"^## \[([^\]]+)\]")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="Version to extract (without the brackets)")
+    parser.add_argument(
+        "--file",
+        default=str(REPO_ROOT / "CHANGELOG.md"),
+        help="Path to CHANGELOG file (default: CHANGELOG.md at repo root)",
+    )
+    args = parser.parse_args()
+
+    path = Path(args.file)
+    if not path.exists():
+        print(f"ERROR: {path} not found", file=sys.stderr)
+        return 1
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    in_section = False
+    body: list[str] = []
+    for line in lines:
+        match = SECTION_RE.match(line)
+        if match:
+            if match.group(1) == args.version:
+                in_section = True
+                continue
+            if in_section:
+                break
+        elif in_section:
+            body.append(line)
+
+    if not in_section:
+        print(f"ERROR: no '## [{args.version}]' section in {path}", file=sys.stderr)
+        return 1
+
+    print("\n".join(body).strip())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/check-version-bump
+++ b/bin/check-version-bump
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Verify a PR includes either a CHANGELOG entry or a version bump.
+
+Designed to run in GitHub Actions on PRs targeting `main`.
+
+Pass conditions (any one):
+  1. PR author is dependabot[bot] (GITHUB_ACTOR env var)
+  2. CHANGELOG.md `[Unreleased]` section has new non-header content vs main
+  3. pyproject.toml version was bumped AND CHANGELOG has a matching `[<version>]`
+     section with content
+
+Fail otherwise. The error message tells the contributor what to do.
+
+Usage:
+  bin/check-version-bump                 # compare HEAD against origin/main
+  bin/check-version-bump --base origin/feature-branch  # custom base
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+VERSION_RE = re.compile(r'^version\s*=\s*"([^"]+)"', re.MULTILINE)
+SECTION_RE = re.compile(r"^## \[([^\]]+)\]", re.MULTILINE)
+
+
+def _git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _file_at(ref: str, path: str) -> str:
+    """Return the contents of `path` at `ref`, or '' if it doesn't exist there."""
+    try:
+        return subprocess.run(
+            ["git", "show", f"{ref}:{path}"],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def _version(text: str) -> str | None:
+    match = VERSION_RE.search(text)
+    return match.group(1) if match else None
+
+
+def _section_body(changelog: str, section: str) -> str:
+    """Return the body of `## [<section>]` until the next `## [` heading."""
+    lines = changelog.splitlines()
+    in_section = False
+    body_lines: list[str] = []
+    for line in lines:
+        match = SECTION_RE.match(line)
+        if match:
+            if match.group(1) == section:
+                in_section = True
+                continue
+            if in_section:
+                break
+        elif in_section:
+            body_lines.append(line)
+    return "\n".join(body_lines).strip()
+
+
+def _has_content(body: str) -> bool:
+    """A section has 'content' if any non-blank line isn't a sub-heading."""
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("###"):
+            continue
+        return True
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base",
+        default="origin/main",
+        help="Git ref to compare against (default: origin/main)",
+    )
+    args = parser.parse_args()
+
+    if os.environ.get("GITHUB_ACTOR") == "dependabot[bot]":
+        print("Skipping: PR author is dependabot[bot]")
+        return 0
+
+    base_pyproject = _file_at(args.base, "pyproject.toml")
+    head_pyproject = PYPROJECT.read_text(encoding="utf-8")
+    base_version = _version(base_pyproject)
+    head_version = _version(head_pyproject)
+
+    if head_version is None:
+        print("ERROR: could not parse version from pyproject.toml", file=sys.stderr)
+        return 1
+
+    head_changelog = CHANGELOG.read_text(encoding="utf-8") if CHANGELOG.exists() else ""
+
+    version_bumped = base_version is not None and head_version != base_version
+
+    if version_bumped:
+        body = _section_body(head_changelog, head_version)
+        if not _has_content(body):
+            print(
+                f"ERROR: pyproject.toml version was bumped to {head_version}, "
+                f"but CHANGELOG.md has no '## [{head_version}]' section with "
+                f"content.\n\n"
+                f"Add a '## [{head_version}] - YYYY-MM-DD' section to CHANGELOG.md "
+                f"summarizing what's in this release.",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            f"OK: version bumped to {head_version}, CHANGELOG has matching "
+            f"[{head_version}] section."
+        )
+        return 0
+
+    base_unreleased = _section_body(_file_at(args.base, "CHANGELOG.md"), "Unreleased")
+    head_unreleased = _section_body(head_changelog, "Unreleased")
+
+    if head_unreleased == base_unreleased:
+        print(
+            "ERROR: this PR adds no entry to CHANGELOG.md '[Unreleased]'.\n\n"
+            "Add a one-line bullet under '## [Unreleased]' describing the "
+            "change. See CLAUDE.md 'Documentation Sync' for which docs need "
+            "updating in the same PR.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("OK: CHANGELOG.md [Unreleased] has new content vs main.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,30 @@ name = "tenor-tui"
 version = "0.1.0"
 description = "A terminal UI for browsing stock options chains"
 readme = "README.md"
+license = "MIT"
+authors = ["Jay Ravaliya <jayrav13@gmail.com>"]
+homepage = "https://jayravaliya.com/tenor-tui/"
+repository = "https://github.com/jayrav13/tenor-tui"
+documentation = "https://jayravaliya.com/tenor-tui/"
+keywords = ["options", "stocks", "tui", "terminal", "trading", "finance", "textual"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console :: Curses",
+    "Intended Audience :: End Users/Desktop",
+    "Intended Audience :: Financial and Insurance Industry",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Office/Business :: Financial :: Investment",
+]
 packages = [{include = "tenortui", from = "src"}]
+
+[tool.poetry.urls]
+Issues = "https://github.com/jayrav13/tenor-tui/issues"
+Changelog = "https://github.com/jayrav13/tenor-tui/blob/main/CHANGELOG.md"
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tenor-tui"
-version = "0.1.0"
+version = "1.0.0"
 description = "A terminal UI for browsing stock options chains"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Second half of the umbrella shipping push (#45). Ships **TenorTUI 1.0.0** to PyPI.

5 commits, each phase a discrete change:

1. `e0397d7` PyPI metadata + MIT LICENSE — wheel passes `twine check`
2. `5112c08` `bin/check-version-bump` + CI gate — every PR needs a CHANGELOG entry or version bump
3. `106b6c3` `release.yml` workflow + `bin/changelog-section` — auto-publish to PyPI via OIDC, tag, GitHub Release
4. `022c7c7` README rewrite — under 80 lines, dev/install/contribute focus, points at docs site
5. `bd10b49` Bump to 1.0.0 — promotes `[Unreleased]` to `[1.0.0]` in CHANGELOG

## What happens on merge

`release.yml` triggers on push to main, detects the version bump (no `v1.0.0` tag exists yet), runs tests, builds the wheel, publishes to PyPI via Trusted Publishing (no API tokens), tags `v1.0.0`, and creates a GitHub Release with the wheel + sdist attached.

The deploy of the docs site has already happened on the previous merge — Pages is live at <https://jayravaliya.com/tenor-tui/>.

## Test plan

- [x] All existing tests pass (430 / 430)
- [x] Lint clean
- [x] `make docs-strict` passes
- [x] `poetry build` produces clean wheel + sdist; `twine check` PASSED
- [x] `bin/check-version-bump` passes locally (recognizes 1.0.0 bump + matching CHANGELOG section)
- [x] `bin/changelog-section 1.0.0` returns the right body
- [ ] CI: lint, test×3, docs-build, **check-version-bump** (new) all pass
- [ ] On merge: release workflow publishes to PyPI, creates GitHub Release
- [ ] `pip install tenor-tui` works after release

## Manual prerequisites (already done)

- [x] PyPI Trusted Publisher pointing at `jayrav13/tenor-tui` + `release.yml` + `release` environment
- [x] GitHub Environment `release` exists on the repo
- [x] PyPI name `tenor-tui` available

Closes #49.

*Co-authored by Claude*