### PR TITLE
fix: PyPI/Python README badges show 'not found' (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- README PyPI/Python badges showed "package or version not found" because
+  shields.io's CDN cached a 404 from before 1.0.0 was published. Added
+  `?v=1` query string to bust the cache.
+
 ## [1.0.0] - 2026-04-27
 
 First public PyPI release. Marks TenorTUI as a stable shipped product.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # TenorTUI
 
-[![PyPI](https://img.shields.io/pypi/v/tenor-tui.svg)](https://pypi.org/project/tenor-tui/)
+[![PyPI](https://img.shields.io/pypi/v/tenor-tui.svg?v=1)](https://pypi.org/project/tenor-tui/)
 [![CI](https://github.com/jayrav13/tenor-tui/actions/workflows/ci.yml/badge.svg)](https://github.com/jayrav13/tenor-tui/actions/workflows/ci.yml)
-[![Python](https://img.shields.io/pypi/pyversions/tenor-tui.svg)](https://pypi.org/project/tenor-tui/)
+[![Python](https://img.shields.io/pypi/pyversions/tenor-tui.svg?v=1)](https://pypi.org/project/tenor-tui/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 A terminal UI for browsing stock options chains. Live quotes, full options


### PR DESCRIPTION
## Summary

Shields.io's CDN cached a 404 for `https://img.shields.io/pypi/v/tenor-tui.svg` and `.../pyversions/tenor-tui.svg` from PR #50, before 1.0.0 was actually published. The JSON endpoints return correct data; only the SVG cache was stale. Appending `?v=1` gives shields.io a fresh cache key.

Verified locally: cache-busted URLs return `pypi v1.0.0` and `python 3.11 | 3.12 | 3.13 | 3.14`.

Closes #51.

## Test plan

- [x] `bin/check-version-bump` passes
- [ ] CI passes
- [ ] After merge: README badges render correct PyPI version + Python versions

*Co-authored by Claude*